### PR TITLE
Fix invalid reference in coursier.bzl

### DIFF
--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -1364,7 +1364,7 @@ pinned_coursier_fetch = repository_rule(
             doc = "Instructions to re-pin the repository if required. Many people have wrapper scripts for keeping dependencies up to date, and would like to point users to that instead of the default.",
         ),
         "excluded_artifacts": attr.string_list(default = []),  # only used for hash generation
-        "_workspace_label": attr.label(default = Label("@//does/not:exist")),
+        "_workspace_label": attr.label(default = Label("@@//does/not:exist")),
     },
     implementation = _pinned_coursier_fetch_impl,
 )


### PR DESCRIPTION
coursier.bzl contains a reference which is not compatible with bzlmod. Fixes #1118.