### PR TITLE
Fix @rules_kotiln reference in kt_jvm_export

### DIFF
--- a/private/rules/kt_jvm_export.bzl
+++ b/private/rules/kt_jvm_export.bzl
@@ -2,7 +2,7 @@ load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load(":java_export.bzl", "maven_export")
 load(":maven_project_jar.bzl", "DEFAULT_EXCLUDED_WORKSPACES")
 
-KOTLIN_STDLIB = "@rules_kotlin//kotlin/compiler:kotlin-stdlib"
+KOTLIN_STDLIB = Label("@rules_kotlin//kotlin/compiler:kotlin-stdlib")
 
 def kt_jvm_export(
         name,


### PR DESCRIPTION
Use Label so that the reference is resolved within the context of rules_jvm_external module and not in the calling workspace

---

In our workspace we include @rules_kotlin under a different name, and without this fix, @rules_kotlin is not resolved as intended.