### PR TITLE
Do not use or recommend `@//` labels with Bzlmod

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ If you are using `bzlmod`, define an `install` tag in your root
 maven.install(
     name = "rules_jvm_external_deps",
     repositories = ["https://mycorp.com/artifacts"],
-    lock_file = "@//:rules_jvm_external_deps_install.json",
+    lock_file = "//:rules_jvm_external_deps_install.json",
 )
 ```
 
@@ -378,8 +378,8 @@ maven.install(
         "org.seleniumhq.selenium:selenium-java",
     ],
     # The `maven` resolver requires a lock file, though this can be an empty file before pinning
-    lock_file = "@//:manifest_install.json",
-)    
+    lock_file = "//:manifest_install.json",
+)
 ```
 
 ## Generated targets

--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -1410,7 +1410,8 @@ pinned_coursier_fetch = repository_rule(
             doc = "Instructions to re-pin the repository if required. Many people have wrapper scripts for keeping dependencies up to date, and would like to point users to that instead of the default.",
         ),
         "excluded_artifacts": attr.string_list(default = []),  # only used for hash generation
-        "_workspace_label": attr.label(default = "@//does/not:exist"),
+        # Use @@// to refer to the main repo with Bzlmod.
+        "_workspace_label": attr.label(default = ("@@" if str(Label("//:invalid")).startswith("@@") else "@") + "//does/not:exist"),
     },
     implementation = _pinned_coursier_fetch_impl,
 )


### PR DESCRIPTION
With Bzlmod, only the root module can refer to its own repo via `@//`. Instead, modules should just use repo-relative labels to refer to themselves, which works even if they aren't the root module.

Avoids this warning with Bazel 8:
```
WARNING: The module extension @@rules_jvm_external+//:extensions.bzl%maven produced an invalid lockfile entry because it referenced @@[unknown repo '' requested from @@rules_jvm_external+]. Please report this issue to its maintainers.
```