### PR TITLE
Remove android_extensions.bzl load

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 
 bazel_dep(
     name = "rules_android",
-    version = "0.1.1",
+    version = "0.5.1",
 )
 bazel_dep(
     name = "bazel_features",
@@ -39,10 +39,6 @@ bazel_dep(
     dev_dependency = True,
     repo_name = "io_bazel_stardoc",
 )
-
-# Remove this once rules_android has rolled out official Bzlmod support
-remote_android_extensions = use_extension("@bazel_tools//tools/android:android_extensions.bzl", "remote_android_tools_extensions")
-use_repo(remote_android_extensions, "android_gmaven_r8", "android_tools")
 
 maven = use_extension(":extensions.bzl", "maven")
 


### PR DESCRIPTION
This has been removed from bazel 8.x, and is included in rules_android
now
