### PR TITLE
Upgrade rules_java and add rule loads

### DIFF
--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -38,6 +38,7 @@ _BUILD = """
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_license//rules:package_info.bzl", "package_info")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_plugin")
 load("@rules_jvm_external//private/rules:pin_dependencies.bzl", "pin_dependencies")
 load("@rules_jvm_external//private/rules:jvm_import.bzl", "jvm_import")
 {aar_import_statement}

--- a/private/rules/java_export.bzl
+++ b/private/rules/java_export.bzl
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_library")
 load(":javadoc.bzl", "javadoc")
 load(":maven_bom_fragment.bzl", "maven_bom_fragment")
 load(":maven_project_jar.bzl", "DEFAULT_EXCLUDED_WORKSPACES", "maven_project_jar")
@@ -90,7 +91,7 @@ def java_export(
     toolchains = kwargs.pop("toolchains", [])
 
     # Construct the java_library we'll export from here.
-    native.java_library(
+    java_library(
         name = lib_name,
         visibility = visibility,
         tags = tags + maven_coordinates_tags,

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "rules_jvm_external",
     srcs = glob(["*.java"]),

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/coursier/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/coursier/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 load("//private/rules:artifact.bzl", "artifact")
 
 java_library(

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/jar/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/jar/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 
 java_binary(

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/javadoc/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/javadoc/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary")
+
 java_binary(
     name = "javadoc",
     srcs = glob(["*.java"]),

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 
 java_binary(

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_library")
 load("//private/rules:artifact.bzl", "artifact")
 
 java_library(

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 
 java_library(

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/events/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/events/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 java_library(
     name = "events",
     srcs = glob(["*.java"]),

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/maven/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/maven/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_library")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 
 java_library(

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/netrc/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/netrc/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_library")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 
 java_library(

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/remote/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/remote/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_library")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 
 java_library(

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/ui/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/ui/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_library")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 
 java_library(

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/zip/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/zip/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 java_library(
     name = "zip",
     srcs = glob(["*.java"]),

--- a/scripts/BUILD
+++ b/scripts/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_binary")
 load("//private:versions.bzl", "COURSIER_CLI_HTTP_FILE_NAME")
 load("//private/rules:artifact.bzl", "artifact")
 

--- a/tests/com/github/bazelbuild/rules_jvm_external/manifest/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/manifest/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary")
+
 java_binary(
     name = "Print",
     srcs = [

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_library")
 load("//:defs.bzl", "artifact")
 
 java_library(

--- a/tests/integration/BUILD
+++ b/tests/integration/BUILD
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@rules_java//java:defs.bzl", "java_library")
 load("//:defs.bzl", "artifact")
 
 genquery(

--- a/tests/integration/java_export/BUILD
+++ b/tests/integration/java_export/BUILD
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@rules_java//java:defs.bzl", "java_library")
 load("//:defs.bzl", "artifact", "java_export")
 load("//private/rules:maven_project_jar.bzl", "maven_project_jar")
 

--- a/tests/integration/maven_bom/BUILD
+++ b/tests/integration/maven_bom/BUILD
@@ -1,5 +1,6 @@
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@rules_java//java:defs.bzl", "java_library")
 load("//:defs.bzl", "artifact", "java_export", "maven_bom")
 
 maven_bom(

--- a/tests/integration/override_targets/BUILD
+++ b/tests/integration/override_targets/BUILD
@@ -1,5 +1,6 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_android//android:rules.bzl", "aar_import")
+load("@rules_java//java:defs.bzl", "java_library")
 
 build_test(
     name = "override_targets",

--- a/tests/integration/plugin_targets/BUILD
+++ b/tests/integration/plugin_targets/BUILD
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 load("//:defs.bzl", "artifact", "java_plugin_artifact")
 
 java_library(

--- a/tests/unit/exports/BUILD
+++ b/tests/unit/exports/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_library")
 load("//tests/unit/exports:exports_test.bzl", "exports_tests")
 
 exports_tests(name = "exports_tests")

--- a/tests/unit/exports/exports_test.bzl
+++ b/tests/unit/exports/exports_test.bzl
@@ -1,7 +1,7 @@
 """Unit tests for exports."""
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
-load("@rules_java//java:defs.bzl", "JavaInfo")
+load("@rules_java//java:defs.bzl", "JavaInfo", "java_library")
 load("//private/rules:has_maven_deps.bzl", "MavenInfo", "has_maven_deps")
 load("//private/rules:maven_project_jar.bzl", "maven_project_jar")
 
@@ -34,33 +34,33 @@ def exports_tests(name):
         target = ":library_to_test",
     )
 
-    native.java_library(
+    java_library(
         name = "library_to_test",
         deps = [":is_dep_has_exports", ":is_export_has_exports"],
         exports = [":is_export_has_exports"],
         srcs = ["Foo.java"],
     )
 
-    native.java_library(
+    java_library(
         name = "is_dep_has_exports",
         deps = [":leaf"],
         exports = [":leaf"],
         srcs = ["Foo.java"],
     )
 
-    native.java_library(
+    java_library(
         name = "is_export_has_exports",
         deps = [":exported_leaf"],
         exports = [":exported_leaf"],
         srcs = ["Foo.java"],
     )
 
-    native.java_library(
+    java_library(
         name = "leaf",
         srcs = ["Foo.java"],
     )
 
-    native.java_library(
+    java_library(
         name = "exported_leaf",
         srcs = ["Foo.java"],
     )

--- a/tests/unit/jvm_import/BUILD
+++ b/tests/unit/jvm_import/BUILD
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_java//java:defs.bzl", "java_import")
 load(":jvm_import_test.bzl", "jvm_import_test_suite")
 
 java_import(


### PR DESCRIPTION
* Upgrade to the latest rules_java 8.1.0
* Add loads for Java rules

NOTE: The loads and rules_java version unforutunately are tightly related. The paths for the bzl files for Java rules changed between rules_java 7 and 8.