### PR TITLE
Add rules_shell and add loads for sh_binary

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,6 +32,10 @@ bazel_dep(
     name = "rules_kotlin",
     version = "1.9.6",
 )
+bazel_dep(
+    name = "rules_shell",
+    version = "0.3.0",
+)
 
 bazel_dep(
     name = "stardoc",

--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -41,6 +41,7 @@ load("@rules_license//rules:package_info.bzl", "package_info")
 load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_plugin")
 load("@rules_jvm_external//private/rules:pin_dependencies.bzl", "pin_dependencies")
 load("@rules_jvm_external//private/rules:jvm_import.bzl", "jvm_import")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 {aar_import_statement}
 
 {imports}

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -79,22 +79,19 @@ def rules_jvm_external_deps(
             url = "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protobuf-27.0.tar.gz",
         )
 
-    # 0.3.0 uses load visibility, which only Bazel 7 has.
-    rules_shell_version = "0.3.0"
-    rules_shell_sha = "d8cd4a3a91fc1dc68d4c7d6b655f09def109f7186437e3f50a9b60ab436a0c53"
-    if major_version == "5" or major_version == "6":
-        rules_shell_version = "0.2.0"
-        rules_shell_sha = "410e8ff32e018b9efd2743507e7595c26e2628567c42224411ff533b57d27c28"
-
     maybe(
         http_archive,
         name = "rules_shell",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_shell/releases/download/v%s/rules_shell-v%s.tar.gz" % (rules_shell_version, rules_shell_version),
-            "https://github.com/bazelbuild/rules_shell/releases/download/v%s/rules_shell-v%s.tar.gz" % (rules_shell_version, rules_shell_version),
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz",
+            "https://github.com/bazelbuild/rules_shell/releases/download/v%s/rules_shell-v0.3.0.tar.gz",
         ],
-        sha256 = rules_shell_sha,
-        strip_prefix = "rules_shell-" + rules_shell_version,
+        sha256 = "d8cd4a3a91fc1dc68d4c7d6b655f09def109f7186437e3f50a9b60ab436a0c53",
+        strip_prefix = "rules_shell-0.3.0",
+        # 0.3.0 uses load visibility and other Bazel 7+ features. Remove this
+        # patch when we stop supporting Bazel 6.
+        patches = ["@//:rules_shell_patch.diff"],
+        patch_args = ["-p1"],
     )
 
     maybe(

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -79,15 +79,22 @@ def rules_jvm_external_deps(
             url = "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protobuf-27.0.tar.gz",
         )
 
+    # 0.3.0 uses load visibility, which only Bazel 7 has.
+    rules_shell_version = "0.3.0"
+    rules_shell_sha = "d8cd4a3a91fc1dc68d4c7d6b655f09def109f7186437e3f50a9b60ab436a0c53"
+    if major_version == "5" or major_version == "6":
+        rules_shell_version = "0.2.0"
+        rules_shell_sha = "410e8ff32e018b9efd2743507e7595c26e2628567c42224411ff533b57d27c28"
+
     maybe(
         http_archive,
         name = "rules_shell",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz",
-            "https://github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_shell/releases/download/v%s/rules_shell-v%s.tar.gz" % (rules_shell_version, rules_shell_version),
+            "https://github.com/bazelbuild/rules_shell/releases/download/v%s/rules_shell-v%s.tar.gz" % (rules_shell_version, rules_shell_version),
         ],
-        sha256 = "d8cd4a3a91fc1dc68d4c7d6b655f09def109f7186437e3f50a9b60ab436a0c53",
-        strip_prefix = "rules_shell-0.3.0",
+        sha256 = rules_shell_sha,
+        strip_prefix = "rules_shell-" + rules_shell_version,
     )
 
     maybe(

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -81,6 +81,17 @@ def rules_jvm_external_deps(
 
     maybe(
         http_archive,
+        name = "rules_shell",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz",
+            "https://github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz",
+        ],
+        sha256 = "d8cd4a3a91fc1dc68d4c7d6b655f09def109f7186437e3f50a9b60ab436a0c53",
+        strip_prefix = "rules_shell-0.3.0",
+    )
+
+    maybe(
+        http_archive,
         name = "rules_license",
         urls = [
             "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/1.0.0/rules_license-1.0.0.tar.gz",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -90,7 +90,7 @@ def rules_jvm_external_deps(
         strip_prefix = "rules_shell-0.3.0",
         # 0.3.0 uses load visibility and other Bazel 7+ features. Remove this
         # patch when we stop supporting Bazel 6.
-        patches = ["@//:rules_shell_patch.diff"],
+        patches = ["@rules_jvm_external//:rules_shell_patch.diff"],
         patch_args = ["-p1"],
     )
 

--- a/rules_shell_patch.diff
+++ b/rules_shell_patch.diff
@@ -1,0 +1,51 @@
+diff --git a/shell/private/sh_binary.bzl b/shell/private/sh_binary.bzl
+index eec109a..f64848c 100644
+--- a/shell/private/sh_binary.bzl
++++ b/shell/private/sh_binary.bzl
+@@ -17,6 +17,6 @@
+ load(":sh_executable.bzl", "make_sh_executable_rule")
+ 
+ # For doc generation only.
+-visibility("public")
++# visibility("public")
+ 
+ sh_binary = make_sh_executable_rule(executable = True)
+diff --git a/shell/private/sh_executable.bzl b/shell/private/sh_executable.bzl
+index 1306c80..7d06595 100644
+--- a/shell/private/sh_executable.bzl
++++ b/shell/private/sh_executable.bzl
+@@ -14,7 +14,7 @@
+ 
+ """Common code for sh_binary and sh_test rules."""
+ 
+-visibility(["//shell"])
++# visibility(["//shell"])
+ 
+ _SH_TOOLCHAIN_TYPE = "//shell:toolchain_type"
+ 
+@@ -189,9 +189,9 @@ most build rules</a>.
+             "_windows_constraint": attr.label(
+                 default = "@platforms//os:windows",
+             ),
+-        } | extra_attrs,
+-        toolchains = [
+-            config_common.toolchain_type(_SH_TOOLCHAIN_TYPE, mandatory = False),
+-        ],
++        }, # | extra_attrs,
++        # toolchains = [
++        #     config_common.toolchain_type(_SH_TOOLCHAIN_TYPE, mandatory = False),
++        # ],
+         **kwargs
+     )
+diff --git a/shell/sh_binary.bzl b/shell/sh_binary.bzl
+index 9e4a30d..8f12326 100644
+--- a/shell/sh_binary.bzl
++++ b/shell/sh_binary.bzl
+@@ -16,6 +16,6 @@
+ 
+ load("//shell/private:sh_binary.bzl", _sh_binary = "sh_binary")
+ 
+-visibility("public")
++# visibility("public")
+ 
+ sh_binary = getattr(native, "sh_binary", _sh_binary)


### PR DESCRIPTION
This is for compatibility with Bazel 8 which does not contain a native sh_binary rule.