### PR TITLE
Fix docs generation for artifacts with compile only dependencies

### DIFF
--- a/private/rules/maven_project_jar.bzl
+++ b/private/rules/maven_project_jar.bzl
@@ -59,8 +59,9 @@ def _maven_project_jar_impl(ctx):
         ctx.attr.excluded_workspaces,
     )
 
+    artifact_srcs = calculate_artifact_source_jars(info)
     artifact_srcs = _strip_excluded_workspace_jars(
-        calculate_artifact_source_jars(info),
+        artifact_srcs,
         ctx.attr.excluded_workspaces,
     )
 


### PR DESCRIPTION
Fixes https://github.com/bazel-contrib/rules_jvm_external/issues/1241
A detailed description of the issue, minimal repo, and explanation of the fix can be found at https://github.com/vinnybod/bazel_java_example/tree/javadocs-srcs-issue?tab=readme-ov-file#solution