### PR TITLE
Make multiple modules contributing to the same maven repo namespace warning less verbose and duplicated

### DIFF
--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -348,9 +348,9 @@ def maven_impl(mctx):
 
     for (repo_name, known_names) in repo_name_2_module_name.items():
         if len(known_names) > 1:
-            print("The maven repository '%s' is used in multiple bzlmod modules: %s" % (
+            print("The maven repository '%s' has contributions from multiple bzlmod modules, and will be resolved together: %s" % (
                 repo_name, # e.g. "maven"
-                str(known_names), # e.g. bzl_module_foo, bzl_module_bar
+                sorted(known_names), # e.g. bzl_module_bar, bzl_module_bar
             ))
 
     # Breaking out the logic for picking lock files, because it's not terribly simple


### PR DESCRIPTION
Fix feedback about noisy logs from https://github.com/bazelbuild/bazel-worker-api/issues/7#issue-2716146027

What was previously:

```
(15:01:37) DEBUG: /private/var/tmp/_bazel_blee/499a001013731d09bffd82f8601a3161/external/rules_jvm_external+/private/extensions/maven.bzl:155:14: The maven repository 'maven' is used in two different bazel modules, originally in 'protobuf' and now in 'bazel_worker_java'
(15:01:37) DEBUG: /private/var/tmp/_bazel_blee/499a001013731d09bffd82f8601a3161/external/rules_jvm_external+/private/extensions/maven.bzl:155:14: The maven repository 'maven' is used in two different bazel modules, originally in 'protobuf' and now in 'bazel_worker_java'
(15:01:37) DEBUG: /private/var/tmp/_bazel_blee/499a001013731d09bffd82f8601a3161/external/rules_jvm_external+/private/extensions/maven.bzl:155:14: The maven repository 'maven' is used in two different bazel modules, originally in 'protobuf' and now in 'bazel_worker_java'
(15:01:37) DEBUG: /private/var/tmp/_bazel_blee/499a001013731d09bffd82f8601a3161/external/rules_jvm_external+/private/extensions/maven.bzl:155:14: The maven repository 'maven' is used in two different bazel modules, originally in 'protobuf' and now in 'bazel_worker_java'
(15:01:37) DEBUG: /private/var/tmp/_bazel_blee/499a001013731d09bffd82f8601a3161/external/rules_jvm_external+/private/extensions/maven.bzl:155:14: The maven repository 'maven' is used in two different bazel modules, originally in 'protobuf' and now in 'bazel_worker_java'
(15:01:37) DEBUG: /private/var/tmp/_bazel_blee/499a001013731d09bffd82f8601a3161/external/rules_jvm_external+/private/extensions/maven.bzl:155:14: The maven repository 'maven' is used in two different bazel modules, originally in 'protobuf' and now in 'bazel_worker_java'
```

should now be:

```
(15:01:37) DEBUG: The maven repository 'maven' has contributions from multiple bzlmod modules, and will be resolved together: ["protobuf", "bazel_worker_java"]
```
