### PR TITLE
[auth][netrc] Empty account fallback to login

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/remote/HttpDownloader.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/remote/HttpDownloader.java
@@ -73,8 +73,13 @@ public class HttpDownloader {
               // to (by default) 3 times, which is not the behaviour we want.
               return null;
             }
-            return new PasswordAuthentication(
-                credential.account(), credential.password().toCharArray());
+
+            String userName = credential.account();
+            if (userName == null || userName.isEmpty()) {
+              userName = credential.login();
+            }
+
+            return new PasswordAuthentication(userName, credential.password().toCharArray());
           }
         };
     builder = builder.authenticator(authenticator);


### PR DESCRIPTION
With this change the following netrc would get the username set, it used to set an **empty username**:

```
machine artifacts.example.org
  login bob
  password superSecretPa$$word
```