### PR TITLE
Fix collection of Maven runtime deps

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -52,7 +52,8 @@ tasks:
       - "//..."
   ubuntu2204_latest:
     platform: ubuntu2204
-    bazel: latest
+    # TODO: Revert to latest after fixing incompatibilities with Bazel 8.0.0
+    bazel: 7.x
     environment:
       # This tests custom cache locations.
       # https://github.com/bazelbuild/rules_jvm_external/pull/316

--- a/private/lib/coordinates.bzl
+++ b/private/lib/coordinates.bzl
@@ -11,6 +11,8 @@ def unpack_coordinates(coords):
         return None
 
     pieces = coords.split(":")
+    if len(pieces) < 2:
+        fail("Could not parse maven coordinate: %s" % coords)
     group = pieces[0]
     artifact = pieces[1]
 

--- a/private/rules/java_export.bzl
+++ b/private/rules/java_export.bzl
@@ -90,6 +90,12 @@ def java_export(
     doc_resources = kwargs.pop("doc_resources", [])
     toolchains = kwargs.pop("toolchains", [])
 
+    # java_library doesn't allow srcs without deps, but users may try to specify deps rather than
+    # runtime_deps on java_export to indicate that the generated POM should list the deps as compile
+    # deps.
+    if kwargs.get("deps") and not kwargs.get("srcs"):
+        fail("deps not allowed without srcs; move to runtime_deps (for 'runtime' scope in the generated POM) or exports (for 'compile' scope)")
+
     # Construct the java_library we'll export from here.
     java_library(
         name = lib_name,

--- a/private/rules/maven_utils.bzl
+++ b/private/rules/maven_utils.bzl
@@ -62,8 +62,12 @@ def generate_pom(
         parent = None,
         versioned_dep_coordinates = [],
         unversioned_dep_coordinates = [],
-        runtime_deps = [],
+        versioned_compile_dep_coordinates = [],
         indent = 8):
+    versioned_compile_dep_coordinates_set = {
+        k: None
+        for k in versioned_compile_dep_coordinates
+    }
     unpacked_coordinates = _unpack_coordinates(coordinates)
     substitutions = {
         "{groupId}": unpacked_coordinates.group,
@@ -93,7 +97,7 @@ def generate_pom(
         include_version = dep in versioned_dep_coordinates
         unpacked = _unpack_coordinates(dep)
 
-        new_scope = "runtime" if dep in runtime_deps else "compile"
+        new_scope = "compile" if dep in versioned_compile_dep_coordinates_set else "runtime"
         if unpacked.packaging == "pom":
             new_scope = "import"
 

--- a/private/rules/pom_file.bzl
+++ b/private/rules/pom_file.bzl
@@ -13,19 +13,21 @@ def _pom_file_impl(ctx):
     additional_deps = determine_additional_dependencies(artifact_jars, ctx.attr.additional_dependencies)
 
     all_maven_deps = info.maven_deps.to_list()
-    runtime_maven_deps = info.maven_runtime_deps.to_list()
+    compile_maven_deps = info.maven_compile_deps.to_list()
 
     for dep in additional_deps:
-        for coords in dep[MavenInfo].as_maven_dep.to_list():
-            all_maven_deps.append(coords)
+        dep_info = dep[MavenInfo]
+        dep_coordinates = [dep_info.coordinates] if dep_info.coordinates else dep_info.as_maven_dep.to_list()
+        all_maven_deps.extend(dep_coordinates)
+        compile_maven_deps.extend(dep_coordinates)
 
     expanded_maven_deps = [
         ctx.expand_make_variables("additional_deps", coords, ctx.var)
         for coords in all_maven_deps
     ]
-    expanded_runtime_deps = [
-        ctx.expand_make_variables("maven_runtime_deps", coords, ctx.var)
-        for coords in runtime_maven_deps
+    expanded_compile_deps = [
+        ctx.expand_make_variables("maven_compile_deps", coords, ctx.var)
+        for coords in compile_maven_deps
     ]
 
     # Expand maven coordinates for any variables to be replaced.
@@ -35,7 +37,7 @@ def _pom_file_impl(ctx):
         ctx,
         coordinates = coordinates,
         versioned_dep_coordinates = sorted(expanded_maven_deps),
-        runtime_deps = expanded_runtime_deps,
+        versioned_compile_dep_coordinates = expanded_compile_deps,
         pom_template = ctx.file.pom_template,
         out_name = "%s.xml" % ctx.label.name,
     )

--- a/tests/unit/runtime_scope/BUILD
+++ b/tests/unit/runtime_scope/BUILD
@@ -1,0 +1,3 @@
+load("//tests/unit/runtime_scope:runtime_scope_test.bzl", "runtime_scope_tests")
+
+runtime_scope_tests(name = "runtime_scope_tests")

--- a/tests/unit/runtime_scope/runtime_scope_test.bzl
+++ b/tests/unit/runtime_scope/runtime_scope_test.bzl
@@ -1,0 +1,146 @@
+"""Unit tests for java_export runtime_deps behavior."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@rules_java//java:defs.bzl", "JavaInfo", "java_library")
+load("//private/rules:has_maven_deps.bzl", "MavenInfo", "has_maven_deps")
+load("//private/rules:maven_project_jar.bzl", "maven_project_jar")
+
+def _runtime_scope_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    tut = analysistest.target_under_test(env)
+
+    asserts.equals(env, [
+        # keep sorted
+        "example:dep_leaf:1.0.0",
+        "example:exported_leaf:1.0.0",
+        "example:leaf:1.0.0",
+        "example:runtime_dep_and_dep_leaf:1.0.0",
+        "example:runtime_dep_leaf:1.0.0",
+    ], sorted(tut[MavenInfo].maven_deps.to_list()))
+    asserts.equals(env, [
+        # keep sorted
+        "example:exported_leaf:1.0.0",
+        "example:leaf:1.0.0",
+        "example:runtime_dep_and_dep_leaf:1.0.0",
+    ], sorted(tut[MavenInfo].maven_compile_deps.to_list()))
+
+    return analysistest.end(env)
+
+_runtime_scope_test = analysistest.make(
+    _runtime_scope_test_impl,
+    extra_target_under_test_aspects = [has_maven_deps],
+)
+
+def runtime_scope_tests(name):
+    java_library(
+        name = "library_to_test",
+        deps = [
+            ":is_dep_has_exports",
+            ":is_dep_has_runtime_deps",
+        ],
+        exports = [":is_export_has_deps"],
+        runtime_deps = [":is_runtime_dep_has_deps"],
+        srcs = ["Foo.java"],
+    )
+
+    java_library(
+        name = "is_dep_has_exports",
+        exports = [
+            ":leaf",
+            ":runtime_dep_and_dep_leaf",
+            ":stop_propagation",
+        ],
+        srcs = ["Foo.java"],
+    )
+
+    java_library(
+        name = "is_dep_has_runtime_deps",
+        runtime_deps = [
+            ":runtime_dep_leaf",
+            ":runtime_dep_and_dep_leaf",
+        ],
+        srcs = ["Foo.java"],
+    )
+
+    java_library(
+        name = "is_export_has_deps",
+        deps = [":exported_leaf"],
+        srcs = ["Foo.java"],
+    )
+
+    java_library(
+        name = "is_runtime_dep_has_deps",
+        deps = [":dep_leaf"],
+        srcs = ["Foo.java"],
+    )
+
+    java_library(
+        name = "leaf",
+        srcs = ["Foo.java"],
+        tags = [
+            "maven_coordinates=example:leaf:1.0.0",
+        ],
+    )
+
+    java_library(
+        name = "exported_leaf",
+        srcs = ["Foo.java"],
+        tags = [
+            "maven_coordinates=example:exported_leaf:1.0.0",
+        ],
+    )
+
+    java_library(
+        name = "dep_leaf",
+        srcs = ["Foo.java"],
+        tags = [
+            "maven_coordinates=example:dep_leaf:1.0.0",
+        ],
+    )
+
+    java_library(
+        name = "runtime_dep_leaf",
+        srcs = ["Foo.java"],
+        tags = [
+            "maven_coordinates=example:runtime_dep_leaf:1.0.0",
+        ],
+    )
+
+    java_library(
+        name = "runtime_dep_and_dep_leaf",
+        srcs = ["Foo.java"],
+        tags = [
+            "maven_coordinates=example:runtime_dep_and_dep_leaf:1.0.0",
+        ],
+        deps = [":transitive_maven_dep"],
+    )
+
+    java_library(
+        name = "stop_propagation",
+        srcs = ["Foo.java"],
+        tags = [
+            "no-maven",
+        ],
+        deps = [":not_included_leaf"],
+    )
+
+    java_library(
+        name = "not_included_leaf",
+        srcs = ["Foo.java"],
+        tags = [
+            "maven_coordinates=example:not_included_leaf:1.0.0",
+        ],
+    )
+
+    java_library(
+        name = "transitive_maven_dep",
+        srcs = ["Foo.java"],
+        tags = [
+            "maven_coordinates=example:transitive_maven_dep:1.0.0",
+        ],
+    )
+
+    _runtime_scope_test(
+        name = name,
+        target_under_test = ":library_to_test",
+    )


### PR DESCRIPTION
A transitive dependency of a `maven_project_jar` is a runtime dependency if and only if each path to it from the root goes through at least one `runtime_deps` edge. Before this commit, every transitive dependency that was reachable from the root via at least one path with a `runtime_deps` edge was considered to be a runtime dependency, even if other paths require it as a compile dependency. This fixes a regression introduced by https://github.com/bazel-contrib/rules_jvm_external/commit/7b0abdc591b9b0b0dbdfd62bf9d98928b0efe6a2.

Also show a helpful error when users attempt to move a dep from `runtime_deps` to `deps` on a `java_export` target with no `srcs`.

Work towards https://github.com/CodeIntelligenceTesting/jazzer/issues/919