### PR TITLE
Rework how we determine coordinate formats

### DIFF
--- a/private/coursier_utilities.bzl
+++ b/private/coursier_utilities.bzl
@@ -16,24 +16,9 @@
 # download them if it's not asked to to resolve "eclipse-plugin".
 
 load("//:specs.bzl", "parse")
+load("//private/lib:coordinates.bzl", _SUPPORTED_PACKAGING_TYPES = "SUPPORTED_PACKAGING_TYPES")
 
-SUPPORTED_PACKAGING_TYPES = [
-    "jar",
-    "json",
-    "aar",
-    "bundle",
-    "eclipse-plugin",
-    "exe",
-    "orbit",
-    "test-jar",
-    "hk2-jar",
-    "maven-plugin",
-    "scala-jar",
-    "dylib",
-    "so",
-    "dll",
-    "pom",
-]
+SUPPORTED_PACKAGING_TYPES = _SUPPORTED_PACKAGING_TYPES
 
 # See https://github.com/bazelbuild/rules_jvm_external/issues/686
 # A single package uses classifier to distinguish the jar files (one per platform),

--- a/private/lib/coordinates.bzl
+++ b/private/lib/coordinates.bzl
@@ -1,3 +1,21 @@
+SUPPORTED_PACKAGING_TYPES = [
+    "aar",
+    "bundle",
+    "dll",
+    "eclipse-plugin",
+    "exe",
+    "dylib",
+    "hk2-jar",
+    "jar",
+    "json",
+    "maven-plugin",
+    "orbit",
+    "pom",
+    "scala-jar",
+    "so",
+    "test-jar",
+]
+
 def unpack_coordinates(coords):
     """Takes a maven coordinate and unpacks it into a struct with fields
     `group`, `artifact`, `version`, `packaging`, `classifier`
@@ -17,6 +35,17 @@ def unpack_coordinates(coords):
     if len(pieces) == 2:
         return struct(group = group, artifact = artifact, version = "", packaging = None, classifier = None)
 
+    # Strictly speaking this could be one of `g:a:p` or `g:a:v` but realistically, it's going to be
+    # a regular `g:a:v` triplet. If that's not what someone wants, they'll need to qualify the
+    # type in some other way
+    if len(pieces) == 3:
+        version = pieces[2]
+        packaging = None
+        if "@" in pieces[2]:
+            (version, packaging) = pieces[2].split("@", 2)
+
+        return struct(group = group, artifact = artifact, version = version, packaging = packaging, classifier = None)
+
     # Unambiguously the original format
     if len(pieces) == 5:
         packaging = pieces[2]
@@ -24,38 +53,32 @@ def unpack_coordinates(coords):
         version = pieces[4]
         return struct(group = group, artifact = artifact, packaging = packaging, classifier = classifier, version = version)
 
-    # If we're using BOMs, the version is optional. That means at this point
-    # we could be dealing with g:a:p or g:a:v
-    is_gradle = pieces[2][0].isdigit()
-
-    if len(pieces) == 3:
-        if is_gradle:
-            if "@" in pieces[2]:
-                (version, packaging) = pieces[2].split("@", 2)
-                return struct(group = group, artifact = artifact, packaging = packaging, version = version, classifier = None)
-            version = pieces[2]
-            return struct(group = group, artifact = artifact, version = version, packaging = None, classifier = None)
-        else:
-            packaging = pieces[2]
-            return struct(group = group, artifact = artifact, packaging = packaging, version = "", classifier = None)
-
     if len(pieces) == 4:
-        if is_gradle:
+        # Either g:a:p:v or g:a:v:c or g:a:v:c@p.
+
+        # Handle the easy case first
+        if "@" in pieces[3]:
+            (classifier, packaging) = pieces[3].split("@", 2)
             version = pieces[2]
-            if "@" in pieces[3]:
-                (classifier, packaging) = pieces[3].split("@", 2)
-                return struct(group = group, artifact = artifact, packaging = packaging, classifier = classifier, version = version)
-            classifier = pieces[3]
-            return struct(group = group, artifact = artifact, classifier = classifier, version = version, packaging = None)
-        else:
+            return struct(group = group, artifact = artifact, packaging = packaging, classifier = classifier, version = version)
+
+        # Experience has show us that versions can be almost anything, but there's a relatively small
+        # pool of packaging types that people use. This isn't a perfect heuristic, but it's Good
+        # Enough for us right now. Previously, we attempted to figure out if the `piece[2]` was a
+        # version by checking to see whether it's a number. Foolish us.
+
+        if pieces[2] in SUPPORTED_PACKAGING_TYPES:
             packaging = pieces[2]
             version = pieces[3]
+            rewritten = "%s:%s:%s@%s" % (group, artifact, version, packaging)
+            print("Assuming %s should be interpreted as %s" % (coords, rewritten))
             return struct(group = group, artifact = artifact, packaging = packaging, version = version, classifier = None)
+        else:
+            version = pieces[2]
+            classifier = pieces[3]
+            return struct(group = group, artifact = artifact, classifier = classifier, version = version, packaging = None)
 
     fail("Could not parse maven coordinate: %s" % coords)
-
-def _is_version_number(part):
-    return part[0].isdigit()
 
 def to_external_form(coords):
     """Formats `coords` as a string suitable for use by tools such as Gradle.

--- a/tests/unit/coordinates_test.bzl
+++ b/tests/unit/coordinates_test.bzl
@@ -42,11 +42,11 @@ complete_original_format_test = unittest.make(_complete_original_format_impl)
 def _original_format_omitting_scope_impl(ctx):
     env = unittest.begin(ctx)
 
-    unpacked = unpack_coordinates("group:artifact:type:1.2.3")
+    unpacked = unpack_coordinates("group:artifact:test-jar:1.2.3")
     asserts.equals(env, "group", unpacked.group)
     asserts.equals(env, "artifact", unpacked.artifact)
     asserts.equals(env, "1.2.3", unpacked.version)
-    asserts.equals(env, "type", unpacked.packaging)
+    asserts.equals(env, "test-jar", unpacked.packaging)
     asserts.equals(env, None, unpacked.classifier)
 
     return unittest.end(env)
@@ -100,10 +100,11 @@ def _multiple_formats_impl(ctx):
 
     coords_to_structs = {
         "groupId:artifactId:1.2.3": struct(group = "groupId", artifact = "artifactId", version = "1.2.3", classifier = None, packaging = None),
-        "groupId:artifactId:type:1.2.3": struct(group = "groupId", artifact = "artifactId", version = "1.2.3", classifier = None, packaging = "type"),
+        "groupId:artifactId:test-jar:1.2.3": struct(group = "groupId", artifact = "artifactId", version = "1.2.3", classifier = None, packaging = "test-jar"),
         "groupId:artifactId:type:classifier:1.2.3": struct(group = "groupId", artifact = "artifactId", version = "1.2.3", classifier = "classifier", packaging = "type"),
         "groupId:artifactId:1.2.3@type": struct(group = "groupId", artifact = "artifactId", version = "1.2.3", classifier = None, packaging = "type"),
         "groupId:artifactId:1.2.3:classifier@type": struct(group = "groupId", artifact = "artifactId", version = "1.2.3", classifier = "classifier", packaging = "type"),
+        "io.netty:netty-transport-native-unix-common:jar:linux-aarch_64:4.1.100.Final": struct(group = "io.netty", artifact = "netty-transport-native-unix-common", version = "4.1.100.Final", classifier = "linux-aarch_64", packaging = "jar"),
     }
 
     for (coords, expected) in coords_to_structs.items():
@@ -113,6 +114,17 @@ def _multiple_formats_impl(ctx):
     return unittest.end(env)
 
 multiple_formats_test = unittest.make(_multiple_formats_impl)
+
+def _unusual_version_format_impl(ctx):
+    env = unittest.begin(ctx)
+
+    unpacked = unpack_coordinates("group:artifact:FY21R16")
+
+    asserts.equals(env, "FY21R16", unpacked.version)
+
+    return unittest.end(env)
+
+unusual_version_format_test = unittest.make(_unusual_version_format_impl)
 
 def coordinates_test_suite():
     unittest.suite(
@@ -125,4 +137,5 @@ def coordinates_test_suite():
         gradle_format_with_type_and_classifier_test,
         gradle_format_with_type_but_no_classifier_test,
         multiple_formats_test,
+        unusual_version_format_test,
     )

--- a/tests/unit/exports/BUILD
+++ b/tests/unit/exports/BUILD
@@ -1,4 +1,3 @@
-load("@rules_java//java:defs.bzl", "java_library")
 load("//tests/unit/exports:exports_test.bzl", "exports_tests")
 
 exports_tests(name = "exports_tests")


### PR DESCRIPTION
The assumption that versions begin with numbers is fatally flawed in reality. Fortunately, where we're trying to disambiguate, most of the time, it's safe to assume that people mean a version number rather than some other format.