### PR TITLE
Give the coursier pin alias public visibility to match others

### DIFF
--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -119,6 +119,7 @@ _BUILD_PIN_ALIAS = """
 alias(
   name = "pin",
   actual = "{unpinned_pin_target}",
+  visibility = ["//visibility:public"],
 )
 """
 


### PR DESCRIPTION
Ran into this when using the alias'd `:pin` in a `rules_multirun` command. matches visibility of other pins. 