### PR TITLE
Use Bazel's JDK to run coursier

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Table of Contents
     - [Fetch and resolve timeout](#fetch-and-resolve-timeout)
     - [Ignoring empty jars](#ignoring-empty-jars)
     - [Duplicate artifact warning](#duplicate-artifact-warning)
+    - [Provide JVM options for artifact resolution](#provide-jvm-options-for-artifact-resolution)
     - [Provide JVM options for Coursier with `COURSIER_OPTS`](#provide-jvm-options-for-coursier-with-coursier_opts)
     - [Resolving issues with nonstandard system default JDKs](#resolving-issues-with-nonstandard-system-default-jdks)
     - [Exporting and consuming artifacts from external repositories](#exporting-and-consuming-artifacts-from-external-repositories)
@@ -103,7 +104,7 @@ support versions 6, 7 and 8.
 
 ## Usage
 
-### Recommended: bzlmod (Bazel 7 and above)
+### With bzlmod (Bazel 7 and above)
 
 If you are starting a new project, or your project is already using Bazel 7 and
 above, we recommend using [`bzlmod`](https://bazel.build/external/overview) to
@@ -1037,6 +1038,15 @@ maven_install(
     duplicate_version_warning = "error"
 )
 ```
+
+### Provide JVM options for artifact resolution
+
+You can set the `JDK_JAVA_OPTIONS` environment variable to provide additional JVM options to the artifact resolver.
+
+```python
+build --repo_env=JDK_JAVA_OPTIONS=-Djavax.net.ssl.trustStore=<path-to-cacerts>
+```
+can be added to your .bazelrc file if you need to specify custom cacerts for artifact resolution.
 
 ### Provide JVM options for Coursier with `COURSIER_OPTS`
 

--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -110,6 +110,7 @@ pin_dependencies(
     fetch_sources = {fetch_sources},
     fetch_javadocs = {fetch_javadocs},
     lock_file = {lock_file},
+    jvm_flags = {jvm_flags},
     visibility = ["//visibility:public"],
 )
 """
@@ -257,6 +258,14 @@ def _get_aar_import_statement_or_empty_str(repository_ctx):
         return ""
 
 def _java_path(repository_ctx):
+    # Allow setting an env var to keep legacy JAVA_HOME behavior
+    use_java_home = repository_ctx.os.environ.get("RJE_COURSIER_USE_JAVA_HOME")
+
+    if use_java_home == None:
+        embedded_java = "../bazel_tools/jdk/bin/java"
+        if _is_file(repository_ctx, embedded_java):
+            return repository_ctx.path(embedded_java)
+
     java_home = repository_ctx.os.environ.get("JAVA_HOME")
     if java_home != None:
         return repository_ctx.path(java_home + "/bin/java")
@@ -693,6 +702,7 @@ def generate_pin_target(repository_ctx, unpinned_pin_target):
             boms = repr(repository_ctx.attr.boms),
             artifacts = repr(repository_ctx.attr.artifacts),
             excluded_artifacts = repr(repository_ctx.attr.excluded_artifacts),
+            jvm_flags = repr(repository_ctx.os.environ.get("JDK_JAVA_OPTIONS")),
             repos = repr(repository_ctx.attr.repositories),
             fetch_sources = repr(repository_ctx.attr.fetch_sources),
             fetch_javadocs = repr(repository_ctx.attr.fetch_javadoc),
@@ -1511,6 +1521,7 @@ coursier_fetch = repository_rule(
     },
     environ = [
         "JAVA_HOME",
+        "JDK_JAVA_OPTIONS",
         "http_proxy",
         "HTTP_PROXY",
         "https_proxy",

--- a/private/rules/pin_dependencies.bzl
+++ b/private/rules/pin_dependencies.bzl
@@ -15,7 +15,7 @@ load("//private/rules:coursier.bzl", "compute_dependency_inputs_signature")
 
 _TEMPLATE = """#!/usr/bin/env bash
 
-{resolver_cmd} --argsfile {config} --resolver {resolver} --input_hash '{input_hash}' --output {output}
+{resolver_cmd} --jvm_flags={jvm_flags} --argsfile {config} --resolver {resolver} --input_hash '{input_hash}' --output {output}
 """
 
 def _stringify_exclusions(exclusions):
@@ -79,6 +79,7 @@ def _pin_dependencies_impl(ctx):
             resolver_cmd = ctx.executable._resolver.short_path,
             resolver = ctx.attr.resolver,
             output = "$BUILD_WORKSPACE_DIRECTORY/" + ctx.attr.lock_file,
+            jvm_flags = ctx.attr.jvm_flags,
         ),
         is_executable = True,
     )
@@ -119,6 +120,9 @@ pin_dependencies = rule(
         "lock_file": attr.string(
             doc = "Location of the generated lock file",
             mandatory = True,
+        ),
+        "jvm_flags": attr.string(
+            doc = "JVM flags to pass to resolver",
         ),
         "_resolver": attr.label(
             executable = True,


### PR DESCRIPTION
Addresses https://github.com/bazel-contrib/rules_jvm_external/issues/445 and  https://github.com/bazel-contrib/rules_jvm_external/issues/1046 by taking the workaround in https://github.com/bazel-contrib/rules_jvm_external/issues/445 and applying it as the default before looking at JAVA_HOME.

I also added a way to give the JVM settings for both coursier and maven if a custom cacerts file was needed.  This can be set by doing
```
build --repo_env=JDK_JAVA_OPTIONS=-Djavax.net.ssl.trustStore=<path-to-cacerts>
```
in `.bazelrc` 
Based on [JDK_JAVA_OPTIONS](https://docs.oracle.com/en/java/javase/11/tools/java.html#GUID-3B1CE181-CD30-4178-9602-230B800D4FAE__USINGTHEJDK_JAVA_OPTIONSLAUNCHERENV-F3C0E3BA)