### PR TITLE
Pass boms during (unpinned) coursier fetch

### DIFF
--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -1275,10 +1275,7 @@ def _coursier_fetch_impl(repository_ctx):
     lock_file_contents = json.decode(result.stdout)
 
     inputs_hash, _ = compute_dependency_inputs_signature(
-        # We are in `coursier_fetch`, and we've decided to require lock files when
-        # using a resolver that can resolve using boms. As such, we lack the `boms`
-        # attr, so pass in an empty array here, which is what we expect.
-        boms = [],
+        boms = repository_ctx.attr.boms,
         artifacts = repository_ctx.attr.artifacts,
         repositories = repository_ctx.attr.repositories,
         excluded_artifacts = repository_ctx.attr.excluded_artifacts,


### PR DESCRIPTION
Addresses https://github.com/bazel-contrib/rules_jvm_external/issues/1328/.

I am unaware of what additional implications this might have so pinging the authors of the original [maven resolver bom PR](https://github.com/bazel-contrib/rules_jvm_external/commit/3ec0bbb95278bf01f4d3e19b6c193d61e79ffc19) @shs96c @tirsen @cheister and of the [coursier resolver bom PR](https://github.com/bazel-contrib/rules_jvm_external/commit/3289580bcb40ae4e90d3ac8d1768405a7c78e22a) @protocol7 for review.