### PR TITLE
Make rules_java_external run without bash on Windows

### DIFF
--- a/.bazelci/examples.yml
+++ b/.bazelci/examples.yml
@@ -102,12 +102,15 @@ tasks:
     working_directory: examples/kt_jvm_export
     build_targets:
       - "//..."
-  kotlin-jvm-export-windows:
-    name: "kt_jvm_export example"
-    platform: windows
-    working_directory: examples/kt_jvm_export
-    build_targets:
-      - "//..."
+
+  #this is failing since rules_kotlin v2.1.3 due to bug.
+  # Uncomment this once https://github.com/bazelbuild/rules_kotlin/issues/1300 is fixed
+  #kotlin-jvm-export-windows:
+  #  name: "kt_jvm_export example"
+  #  platform: windows
+  #  working_directory: examples/kt_jvm_export
+  #  build_targets:
+  #    - "//..."
   pom-file-generation-linux:
     name: "POM file generation example"
     platform: ubuntu1804

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -99,12 +99,8 @@ tasks:
       - bazel run @regression_testing_coursier//:pin
       - bazel run @regression_testing_maven//:pin
       - bazel run @maven_install_in_custom_location//:pin
-      - bash tests/bazel_run_tests.sh #This be successful without bash.
-    test_targets:
-      - "--"
-      - "//..."
-      - "-//tests/..." #//tests/... have bash. So test them in the other windows task.
-
+      - bash tests/bazel_run_tests.sh #This should run successfully without bash.
+    
   windows_tests_withbash:
     #This setup has bash, so we can test the bashful tests in //tests/...
     platform: windows

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -81,17 +81,38 @@ tasks:
     test_targets:
       - "//..."
       # manual tests
-  windows:
-    environment:
+
+  windows_bashless:
+    #This setup ensures that rules_jvm_external works without bash on Windows. 
+    # note: this doesn't build targets under //tests/..., so its ok to use bash in the //tests area. Just don't use bash in the other areas.
+
+    platform: windows
+    environment:      
+      BAZEL_SH: dummy #set BAZEL_SH to dummy so it won't get Bash. (Bazel will fallback to bash if BAZEL_SH is not set)
+      MSYS2_ARG_CONV_EXCL: "*"
+
       # This tests custom cache locations.
       # https://github.com/bazelbuild/rules_jvm_external/pull/316
       COURSIER_CACHE: /tmp/custom_coursier_cache
       REPIN: 1
-    shell_commands:
+    batch_commands:
       - bazel run @regression_testing_coursier//:pin
       - bazel run @regression_testing_maven//:pin
       - bazel run @maven_install_in_custom_location//:pin
-      - tests/bazel_run_tests.sh
+      - bash tests/bazel_run_tests.sh #This be successful without bash.
+    test_targets:
+      - "--"
+      - "//..."
+      - "-//tests/..." #//tests/... have bash. So test them in the other windows task.
+
+  windows_tests_withbash:
+    #This setup has bash, so we can test the bashful tests in //tests/...
+    platform: windows
+    environment:
+      # This tests custom cache locations.
+      # https://github.com/bazelbuild/rules_jvm_external/pull/316
+      COURSIER_CACHE: /tmp/custom_coursier_cache
+      REPIN: 1    
     test_targets:
       - "--"
       - "//..."

--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -36,14 +36,15 @@ def _genrule_copy_artifact_from_http_file(artifact, visibilities):
     file = artifact.get("out", artifact["file"])
 
     genrule = [
-        "genrule(",
+        "copy_file(",
         "     name = \"%s_extension\"," % http_file_repository,
-        "     srcs = [\"@%s//file\"]," % http_file_repository,
-        "     outs = [\"%s\"]," % file,
-        "     cmd = \"cp $< $@\",",
+        "     src = \"@%s//file\"," % http_file_repository,
+        "     out = \"%s\"," % file,
     ]
     if get_packaging(artifact["coordinates"]) == "exe":
-        genrule.append("     executable = True,")
+        #genrule.append("     executable = True,")
+        genrule.append("     is_executable = True,")
+    
     genrule.extend([
         "     visibility = [%s]" % (",".join(["\"%s\"" % v for v in visibilities])),
         ")",
@@ -135,11 +136,11 @@ def _generate_target(
         dylib = simple_coord.split(":")[-1] + "." + packaging
         to_return.append(
             """
-genrule(
+copy_file(
     name = "{dylib}_extension",
-    srcs = ["@{repository}//file"],
-    outs = ["{dylib}"],
-    cmd = "cp $< $@",
+    src ="@{repository}//file",
+    out = "{dylib}",
+    #cmd = "cp $< $@",
     visibility = ["//visibility:public"],
 )""".format(
                 dylib = dylib,

--- a/private/lib/urls.bzl
+++ b/private/lib/urls.bzl
@@ -89,7 +89,7 @@ def get_m2local_url(repo_os, path_func, artifact):
     if _is_windows(repo_os):
         user_home = repo_os.environ.get("USERPROFILE").replace("\\", "/")    
     else:
-        user_home = repo_os.environ.get("HOME").remove_prefix("/") #url path doesn't have leading /
+        user_home = repo_os.environ.get("HOME")
 
     local_path = artifact["file"]
 
@@ -104,5 +104,6 @@ def get_m2local_url(repo_os, path_func, artifact):
 
     path = path_func(local_path)
     if path.exists:
+        local_path = local_path.removeprefix("/") #leading / in path is not part of url.
         return "file:///%s" % local_path
     return None

--- a/private/lib/urls.bzl
+++ b/private/lib/urls.bzl
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
 def split_url(url):
     protocol = url[:url.find("://")]
     url_without_protocol = url[url.find("://") + 3:]
@@ -85,9 +87,9 @@ def _is_windows(repository_os):
 
 def get_m2local_url(repo_os, path_func, artifact):
     if _is_windows(repo_os):
-        user_home = repo_os.environ.get("USERPROFILE").replace("\\", "/")
+        user_home = repo_os.environ.get("USERPROFILE").replace("\\", "/")    
     else:
-        user_home = repo_os.environ.get("HOME")
+        user_home = repo_os.environ.get("HOME").remove_prefix("/") #url path doesn't have leading /
 
     local_path = artifact["file"]
 
@@ -96,10 +98,11 @@ def get_m2local_url(repo_os, path_func, artifact):
         # version of the lock file
         return None
 
-    if not local_path.startswith("/"):
+    
+    if not paths.is_absolute(local_path):
         local_path = "%s/.m2/repository/%s" % (user_home, local_path)
 
     path = path_func(local_path)
     if path.exists:
-        return "file://%s" % local_path
+        return "file:///%s" % local_path
     return None

--- a/private/lib/utils.bzl
+++ b/private/lib/utils.bzl
@@ -1,0 +1,7 @@
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+def is_windows(ctx):
+    return ctx.configuration.host_path_separator == ";"
+
+def file_to_rlocationpath(ctx, file):
+    return paths.normalize(ctx.workspace_name + "/" + file.short_path)

--- a/private/outdated.bat
+++ b/private/outdated.bat
@@ -1,0 +1,18 @@
+::IMPORTANT: Keep functionality in this Bat in sync with the bash version (pin.sh)
+
+@echo off
+
+call %BAT_RUNFILES_LIB% rlocation outdated_jar_path %1 || goto eof
+call %BAT_RUNFILES_LIB% rlocation artifacts_file_path %2 || goto eof
+call %BAT_RUNFILES_LIB% rlocation boms_file_path %3 || goto eof
+call %BAT_RUNFILES_LIB% rlocation repositories_file_path %4 || goto eof
+set extra_option_flag=%5
+
+java {proxy_opts} -jar "%outdated_jar_path%" ^
+  --artifacts-file "%artifacts_file_path%" ^
+  --boms-file "%boms_file_path%" ^
+  --repositories-file "%repositories_file_path%" ^
+  %extra_option_flag% ^
+  || goto eof
+
+:eof

--- a/private/outdated.sh
+++ b/private/outdated.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+#IMPORTANT: Keep functionality in this Bat in sync with the win bat version (pin.bat)
+
 set -e -o pipefail
 
 outdated_jar_path=$1

--- a/private/pin.bat
+++ b/private/pin.bat
@@ -1,0 +1,17 @@
+::IMPORTANT: Keep functionality in this Bat in sync with the bash version (pin.sh)
+
+@echo off
+call %BAT_RUNFILES_LIB% rlocation maven_unsorted_file %1 || goto eof
+
+set maven_install_json_loc=%BUILD_WORKSPACE_DIRECTORY%\{maven_install_location}
+
+copy /y "%maven_unsorted_file%" "%maven_install_json_loc%" || goto eof
+
+if  "{predefined_maven_install}" == "True" (
+{success_msg_pinned}
+) else (
+{success_msg_unpinned}
+)
+echo:
+
+:eof

--- a/private/pin.sh
+++ b/private/pin.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+#IMPORTANT: Keep functionality in this Bat in sync with the win bat version (pin.bat)
+
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
 set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
@@ -19,39 +21,13 @@ if [[ ! -e $maven_unsorted_file ]]; then
   maven_unsorted_file="${1#..\/}"
 fi
 if [[ ! -e $maven_unsorted_file ]]; then (echo >&2 "Failed to locate the unsorted_deps.json file: $1" && exit 1) fi
-readonly maven_install_json_loc={maven_install_location}
+readonly maven_install_json_loc=$BUILD_WORKSPACE_DIRECTORY/{maven_install_location}
 
 cp "$maven_unsorted_file" "$maven_install_json_loc"
 
 if [ "{predefined_maven_install}" = "True" ]; then
-    echo "Successfully pinned resolved artifacts for @{repository_name}, $maven_install_json_loc is now up-to-date."
+{success_msg_pinned}    
 else
-    echo "Successfully pinned resolved artifacts for @{repository_name} in $maven_install_json_loc." \
-      "This file should be checked into your version control system."
-    echo
-    echo "Next, please update your WORKSPACE file by adding the maven_install_json attribute" \
-      "and loading pinned_maven_install from @{repository_name}//:defs.bzl".
-    echo
-    echo "For example:"
-    echo
-    cat <<EOF
-=============================================================
-
-maven_install(
-    artifacts = # ...,
-    repositories = # ...,
-    maven_install_json = "@//:{repository_name}_install.json",
-)
-
-load("@{repository_name}//:defs.bzl", "pinned_maven_install")
-pinned_maven_install()
-
-=============================================================
-EOF
-
-    echo
-    echo "To update {repository_name}_install.json, run this command to re-pin the unpinned repository:"
-    echo
-    echo "    bazel run @unpinned_{repository_name}//:pin"
+{success_msg_unpinned}
 fi
 echo

--- a/private/windows/BUILD.bazel
+++ b/private/windows/BUILD.bazel
@@ -1,0 +1,21 @@
+load("private/utils.bzl", "run_binary")
+
+exports_files(["runfiles.bat"], visibility = ["//visibility:public"])
+
+#Create a bat_launcher_template that has the runfiles.bat contents embedded in it. (This simulates having the runfiles 'compiled' into the launcher)
+# (Use custom run_binary. (Don't use genrule or skylib's run_binary since they undesirably unhermetic system env vars)
+run_binary(
+    name="bat_launcher_template",
+    tool="private/bat_launcher_maker.bat",
+    outs = ["bat_launcher_template.tmpl"],
+    srcs = [
+        "runfiles.bat",
+        "private/bat_launcher.bat"
+    ],
+    env = {
+        "OUTFILE": "$(execpath bat_launcher_template.tmpl)",
+        "RUNFILE_LIB_PATH": "$(execpath runfiles.bat)",
+        "BATLAUNCHER_PATH": "$(execpath private/bat_launcher.bat)",        
+    },
+    visibility = ["//visibility:public"],
+)

--- a/private/windows/bat_binary.bzl
+++ b/private/windows/bat_binary.bzl
@@ -1,0 +1,67 @@
+load("//private/lib:utils.bzl", "file_to_rlocationpath")
+
+def _bat_binary_imp(ctx):
+    return bat_binary_action(
+        ctx = ctx,
+        src = ctx.file.src,
+        src_defaultinfo = ctx.attr.src[DefaultInfo],
+        data_defaultinfos = [d[DefaultInfo] for d in ctx.attr.data],
+    )
+    
+"""bat_binary_action: Can be directly by rules to create a bat_binary executable as an action"""
+def bat_binary_action(
+    ctx,
+    src, #File
+    src_defaultinfo = None, #DefaultInfo or None. for transient runfiles
+    data_files = [], #Seq[File]
+    data_defaultinfos = [], #Seq[DefaultInfo] (brings in transient runfiles)
+):
+    if(src.extension.upper() != "BAT"):
+        fail("bat_binary src needs to be a *.bat file.")
+    
+    #Create bat launcher    
+    launcher = ctx.actions.declare_file(ctx.label.name + "_launcher.bat")    
+
+    ctx.actions.expand_template(
+        template = ctx.file._launcher_template, 
+        output = launcher,
+        substitutions = {
+            "{runfiles_lib_rpath}" : file_to_rlocationpath(ctx, ctx.file._runfiles_bat),
+            "{script_rpath}" : file_to_rlocationpath(ctx, src),
+        }
+    )
+  
+    data_runfiles_list = [
+        data_item.default_runfiles.merge(ctx.runfiles(data_item.files.to_list()))
+        for data_item in data_defaultinfos
+    ]
+
+    if(src_defaultinfo != None):
+        data_runfiles_list.append(src_defaultinfo.default_runfiles)
+
+    return DefaultInfo(
+        executable = launcher,
+        runfiles = ctx.runfiles([src, ctx.file._runfiles_bat] + data_files).merge_all(data_runfiles_list)
+    )
+
+BAT_BINARY_IMPLICIT_ATTRS = {
+    "_runfiles_bat": attr.label(allow_single_file=True, default="runfiles.bat"),
+    "_launcher_template": attr.label(allow_single_file=True, default="bat_launcher_template"),
+}
+
+
+bat_binary = rule(
+    implementation = _bat_binary_imp,
+    doc = "bat_binary is used to declare executable bat scripts for windows. This rule ensures " + 
+    "all dependencies are built and appear in the runfiles area during execution. \n\n" + 
+    "This rule also sets up the BAT_RUNFILES_LIB env var that contains the path to the bat runfiles lib" +  
+    "which can be used by the bat file to perform rlocation lookups. See comments in runfiles.bat for more info. \n" + 
+    "Example: call %BAT_RUNFILES_LIB% rlocation ACTUAL_PATH %MY_RLOCATIONPATH%",
+        
+    attrs = {
+        "src" : attr.label(allow_single_file=[".bat"], mandatory=True),
+        "data": attr.label_list(allow_files=True),
+   
+    } | BAT_BINARY_IMPLICIT_ATTRS,
+    executable = True
+)

--- a/private/windows/private/bat_launcher.bat
+++ b/private/windows/private/bat_launcher.bat
@@ -1,0 +1,36 @@
+@echo off
+
+::Windows Bat Launcher
+::This Bat launcher is needed since Bazel's win launcher doesn't currently support Bat files. 
+::The main function is to initialize the Runfiles Mechanism:
+::  -- The runfiles library is embedded into the launcher file, which is needed because locating the runfiles lib requires runfiles. Doing it this way makes it so the downstream bat files don't need to embed large runfiles fragment like Bash sh files do.
+::  -- sets BAT_RUNFILES_LIB to the path of the runfiles lib so that downstream bat files will have correct path for Runfiles.
+
+:launcher_start
+
+set BAT_RUNFILES_LIB=:runfiles_call
+ 
+call %BAT_RUNFILES_LIB% initialize %~0 || goto eof
+
+
+call %BAT_RUNFILES_LIB% rlocation RUNFILES_LIB_PATH {runfiles_lib_rpath} || goto eof
+call %BAT_RUNFILES_LIB% rlocation SCRIPT_PATH {script_rpath} || goto eof
+
+
+::Use () block so that the vars will be expanded and we can unset local vars so the local vars don't get inherited by subscript.
+(
+    setlocal
+    
+    ::Unset local vars so subscript will not see them
+    set SCRIPT_PATH=
+    set RUNFILES_LIB_PATH=
+
+    ::Setup the RUNFILES_LIB for the subscript
+    set BAT_RUNFILES_LIB=call "%RUNFILES_LIB_PATH%"
+
+    call "%SCRIPT_PATH%" %* || goto eof
+
+    endlocal
+)
+
+:eof

--- a/private/windows/private/bat_launcher_maker.bat
+++ b/private/windows/private/bat_launcher_maker.bat
@@ -1,0 +1,16 @@
+@echo off
+
+::Ensure using windows backslashes
+set OUTFILE=%OUTFILE:/=\%
+set RUNFILE_LIB_PATH=%RUNFILE_LIB_PATH:/=\%
+set BATLAUNCHER_PATH=%BATLAUNCHER_PATH:/=\%
+
+::Make launcher template by combining launcher.bat and runfileslib.bat
+echo @echo off > %OUTFILE%
+echo goto launcher_start >> %OUTFILE%
+echo rem =========START EMBEDDED RUNFILES_LIB===================== >> %OUTFILE%
+type %RUNFILE_LIB_PATH% >> %OUTFILE%
+echo rem =========END EMBEDDED RUNFILES_LIB===================== >> %OUTFILE%
+echo:  >> %OUTFILE%
+echo:  >> %OUTFILE%
+type %BATLAUNCHER_PATH% >> %OUTFILE%

--- a/private/windows/private/utils.bzl
+++ b/private/windows/private/utils.bzl
@@ -1,0 +1,45 @@
+
+
+def _run_binary_imp(ctx):
+    tool_as_list = [ctx.attr.tool]
+    args = [ctx.expand_location(a, tool_as_list) for a in ctx.attr.args]
+    env = {k: ctx.expand_location(v, tool_as_list) 
+      for k, v 
+      in ctx.attr.env.items()
+    }
+
+    ctx.actions.run(
+        executable = ctx.executable.tool,
+        inputs = ctx.files.srcs,
+        outputs = ctx.outputs.outs,
+        arguments = args,
+        env = env,
+        mnemonic = "RunBinary",
+        use_default_shell_env = ctx.attr.use_default_shell_env,
+    )
+    return DefaultInfo(
+        files = depset(ctx.outputs.outs),        
+    )
+
+
+#run_binary: Runs a binary as a build action.
+#  Note: Similar to Skylib's run_binary, but Skylib's implementation uses default_shell_env which makes it less hermetic on windows.
+#  This implementation allows for more hermeticity by allowing user to set use_default_shell_env=False when they don't need the shell env.
+#  (If/when skylib changes their implementation (skylib #567), this can probably be replaced with that one)
+run_binary = rule(
+    implementation = _run_binary_imp,
+    attrs = {
+        "tool" : attr.label(
+            executable = True,
+            allow_files = True,
+            mandatory = True,
+            cfg = "exec"
+        ),
+        "env": attr.string_dict(),
+        "outs": attr.output_list(mandatory = True),
+        "args": attr.string_list(),
+        "srcs": attr.label_list(allow_files=True),
+        "use_default_shell_env": attr.bool(default = False)
+    }
+
+)

--- a/private/windows/runfiles.bat
+++ b/private/windows/runfiles.bat
@@ -1,0 +1,100 @@
+@echo off
+
+:: Bazel Runfiles lookup library for Windows BATCH files
+:: If using bat_binary, BAT_RUNFILES_LIB should be already set. If not, you can set it yoruself or use the path directly when using 'call'.
+:: Functions:
+::   - initialize <binaryName>: 
+::      Initializes runfileslib and sets runfile envvars. Top level binary needs to call initialize (but this is done by the launcher if using bat_binary).
+::      args: %1 = name of the binary (used to determine runfiles directory).
+::      example: call %BAT_RUNFILES_LIB% initialize %~0
+::   - rlocation <Varname> <rlocationpath>:
+::      Looks up the rlocationpath and sets the Varname Variable to the actual path. The path returned will have windows backslashes '\'. 
+::      args: %1 = Variable Name where the result of the lookup will go. It will have the actual path for the rpathlocation.
+::            %2 = THe rlocation path that is to be looked up. This should be created using the Bazel make variable $(rlocationpath).
+::      example: 
+::         call %BAT_RUNFILES_LIB% rlocation ActualPath %MyRlocationpath%
+::         echo %MyRlocationpath% mapped to %ActualPath%
+:: 
+:: NOTE: repo_mapping functionality is not currently implemented. This is OK since this library is currently only used in rules_jvm_external which uses 
+::     rpathlocation for all its paths.  repo_mapping should probably be added to this lib if it is ever used outside rules_jvm_external
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+:runfiles_call
+
+set function_call=%1
+shift
+
+if "%function_call%" == "rlocation" (
+    goto runfiles_rlocation
+) else if "%function_call%" == "initialize" (    
+    goto runfiles_initialize
+) else (
+    echo "invalid runfiles function: %function_call%"
+    exit /b 1
+)
+
+:::::::::::::::::::::::::::::::::::::::::::::::
+:runfiles_initialize
+::args: %1 = name of the binary (used to determine runfiles directory).
+::example: call BAT_RUNFILES_LIB initialize %~0
+
+rem Force MANFIEST_ONLY since Bazel doesn't have a way for a binary to know if runfiles are enabled or not (yet).
+set RUNFILES_MANIFEST_ONLY=1
+
+if not defined RUNFILES_DIR (    
+
+    rem Assuming the runfiles directory is the name of the binary + ".runfiles"
+
+    set RUNFILES_DIR=%1.runfiles
+)
+if not defined RUNFILES_MANIFEST_FILE (
+    set RUNFILES_MANIFEST_FILE=%RUNFILES_DIR%\Manifest
+)
+
+exit /b 0
+:::::::::::::::::::::::::::::::::::::::::::::::
+
+:::::::::::::::::::::::::::::::::::::::::::::::
+:runfiles_rlocation
+::args: %1 = Variable Name where the result of the lookup will go. It will have the actual path for the rpathlocation.
+::      %2 = THe rlocation path that is to be looked up. This should be created using the Bazel make variable $(rlocationpath).
+::example: call BAT_RUNFILES_LIB rlocation ACTUAL_PATH %MYRLOCATIONPATH%
+
+setlocal enableDelayedExpansion    
+
+set result=
+
+if "%RUNFILES_MANIFEST_ONLY%" == "1" (    
+    if "%RUNFILES_MANIFEST_FILE%" == "" (
+        echo ERROR: rlocation failed. RUNFILES_MANIFEST_FILE is not set. Make sure runfiles are initialized by calling the initialize function.
+        exit /b 1 
+    )
+
+    for /f "tokens=1,2" %%a in ( %RUNFILES_MANIFEST_FILE% ) do (
+        if "%%a" == "%2" (
+            set result=%%b
+            goto runfiles_rlocation_processresult
+        )
+    )
+) else (
+    if "%RUNFILES_DIR%" == "" (
+        echo ERROR: rlocation failed. RUNFILES_DIR is not set. Make sure runfiles are initialized by calling the initialize function.
+        exit /b 1 
+    )
+
+    set result=%RUNFILES_DIR%/%2
+)
+
+:runfiles_rlocation_processresult
+
+if "%result%" == "" (
+  echo ERROR: rlocation failed on %2
+  exit /b 1 
+)
+set "result=%result:/=\%"
+
+endlocal & set %1=%result%
+exit /b 0
+:::::::::::::::::::::::::::::::::::::::::::::::
+
+


### PR DESCRIPTION
With this PR, rules_java_external can now run without Bash on Windows. This makes it way better for Windows users, and helps address hermeticity issues when bazel rules use bash. 

This should address this comment:
https://github.com/bazel-contrib/rules_jvm_external/blob/d8af22108bd8b353a226140570008231f2921931/private/rules/coursier.bzl#L306

Overview:
- I added a new rule bat_binary(), which is a rule I have used successfully in other projects. It should handle runfiles and subcalls properly.
- The main functionality that needed to be adapted to bat_binary were: pin, outdated, and maven_publish. Also deps.bzl now uses skylib's copy_file() instead of a genrule.
- The urls.bzl was changed to make Windows URL correctly.
- CI now has a windows_bashless configuration to build and test in an environment without bash. (There is still a windows_withbash configuration that allows rje to use bash in //tests/...)

So to keep rules_java_external bashless on windows moving forward,  we need to watch where we use sh_binary(), and genrule() to ensure there's a bashless equivelent functionality.  Tests however can still use bash, (but bazel_run_tests should be able to run bashless on windows).

