### PR TITLE
Flip `fail_if_repin_required` to `True` by default

### DIFF
--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -84,7 +84,7 @@ install = tag_class(
                 "none",
             ],
         ),
-        "fail_if_repin_required": attr.bool(doc = "Whether to fail the build if the maven_artifact inputs have changed but the lock file has not been repinned.", default = False),
+        "fail_if_repin_required": attr.bool(doc = "Whether to fail the build if the maven_artifact inputs have changed but the lock file has not been repinned.", default = True),
         "lock_file": attr.label(),
         "repositories": attr.string_list(default = DEFAULT_REPOSITORIES),
         "generate_compat_repositories": attr.bool(

--- a/private/rules/maven_install.bzl
+++ b/private/rules/maven_install.bzl
@@ -22,7 +22,7 @@ def maven_install(
         resolve_timeout = 600,
         additional_netrc_lines = [],
         use_credentials_from_home_netrc_file = False,
-        fail_if_repin_required = False,
+        fail_if_repin_required = True,
         use_starlark_android_rules = False,
         aar_import_bzl_label = DEFAULT_AAR_IMPORT_LABEL,
         duplicate_version_warning = "warn",


### PR DESCRIPTION
It's a common mistake to update the artifacts or boms in the maven_install declarations but then fail to update the lock file. Flipping this flag gives people a safer way of using this ruleset.