### PR TITLE
Convert maven extension to use structs for artifacts and boms

### DIFF
--- a/private/lib/coordinates.bzl
+++ b/private/lib/coordinates.bzl
@@ -28,6 +28,15 @@ def unpack_coordinates(coords):
     if not coords:
         return None
 
+    if type(coords) == "dict":
+        return struct(
+            group = coords["group"],
+            artifact = coords["artifact"],
+            version = coords.get("version", ""),
+            packaging = coords.get("packaging", None),
+            classifier = coords.get("classifier", None),
+        )
+
     pieces = coords.split(":")
     if len(pieces) < 2:
         fail("Could not parse maven coordinate: %s" % coords)


### PR DESCRIPTION
Previously, the lists of `artifacts` and `boms` were a mix of either strings or structs. This makes handling them error prone. It's simpler for us to only use a single format, and the structs are more expressive as we can also set attributes like `testonly`.