### PR TITLE
Avoid spurious warnings about poorly formatted artifact coordinates

### DIFF
--- a/private/coursier_utilities.bzl
+++ b/private/coursier_utilities.bzl
@@ -17,7 +17,7 @@
 
 # Do not load from external dependencies since this is called from the `repositories.bzl` file
 # TODO: lift this restriction once we drop workspace-based build support
-load("//:specs.bzl", "parse")
+
 load("//private/lib:coordinates.bzl", "unpack_coordinates", _SUPPORTED_PACKAGING_TYPES = "SUPPORTED_PACKAGING_TYPES")
 
 SUPPORTED_PACKAGING_TYPES = _SUPPORTED_PACKAGING_TYPES
@@ -41,56 +41,68 @@ def struct_to_dict(s):
         if key != "to_json" and key != "to_proto"
     }
 
-def strip_packaging_and_classifier(coord):
-    # Strip some packaging and classifier values.
+def to_repository_name(coords):
+    """Converts `coords` into group:artifact[:packaging[:classifier]]:version"""
+    unpacked = unpack_coordinates(coords)
 
-    # We want to modify some of the values
-    unpacked_struct = unpack_coordinates(coord)
-    unpacked = {} | struct_to_dict(unpacked_struct)
+    to_return = "%s:%s" % (unpacked.group, unpacked.artifact)
 
-    if unpacked.get("classifier", None) in ["sources", "natives"]:
-        unpacked["classifier"] = None
+    if unpacked.packaging:
+        to_return += ":%s" % unpacked.packaging
+
+    if unpacked.classifier:
+        to_return += ":%s" % unpacked.classifier
+
+    if unpacked.version:
+        to_return += ":%s" % unpacked.version
+
+    return escape(to_return)
+
+def _to_legacy_format(coord, include_version):
+    unpacked = unpack_coordinates(coord)
+
+    to_return = "%s:%s" % (unpacked.group, unpacked.artifact)
 
     # Note that although "pom" is not a packaging type that Coursier CLI accepts,
     # it's included in the `SUPPORTED_PACKAGING_TYPES` array so we don't need to
     # check it here as well.
-    if unpacked.get("packaging", None) in SUPPORTED_PACKAGING_TYPES:
-        unpacked["packaging"] = None
+    if unpacked.packaging and not unpacked.packaging in SUPPORTED_PACKAGING_TYPES:
+        to_return += ":%s" % unpacked.packaging
 
+    if unpacked.classifier and not unpacked.classifier in ["sources", "natives"]:
+        to_return += ":%s" % unpacked.classifier
+
+    if include_version and unpacked.version:
+        to_return += ":%s" % unpacked.version
+
+    return to_return
+
+def strip_packaging_and_classifier(coord):
+    # Strip some packaging and classifier values.
+    #
     # We are expected to return one of:
     #
     # groupId:artifactId:version
     # groupId:artifactId:packaging:version
     # groupId:artifactId:packaging:classifier:version
-    #
-    # TODO: check call sites and see what people do with the returned string
-    # Can we use use coordinates.bzl%to_external_form?
-    to_return = unpacked["group"]
-    for item in ["artifact", "packaging", "classifier", "version"]:
-        if unpacked.get(item, None):
-            to_return += ":" + unpacked[item]
-    return to_return
+
+    return _to_legacy_format(coord, True)
 
 def strip_packaging_and_classifier_and_version(coord):
-    coordinates = coord.split(":")
-
-    # Support for simplified versionless groupId:artifactId coordinate format
-    if len(coordinates) == 2:
-        return ":".join(coordinates)
-    return ":".join(strip_packaging_and_classifier(coord).split(":")[:-1])
+    return _to_legacy_format(coord, False)
 
 def match_group_and_artifact(source, target):
-    source_coord = parse.parse_maven_coordinate(source)
-    target_coord = parse.parse_maven_coordinate(target)
-    return source_coord["group"] == target_coord["group"] and source_coord["artifact"] == target_coord["artifact"]
+    source_coord = unpack_coordinates(source)
+    target_coord = unpack_coordinates(target)
+    return source_coord.group == target_coord.group and source_coord.artifact == target_coord.artifact
 
 def get_packaging(coord):
     # Get packaging from the following maven coordinate
-    return parse.parse_maven_coordinate(coord).get("packaging", None)
+    return unpack_coordinates(coord).packaging
 
 def get_classifier(coord):
     # Get classifier from the following maven coordinate
-    return parse.parse_maven_coordinate(coord).get("classifier", None)
+    return unpack_coordinates(coord).classifier
 
 def escape(string):
     for char in [".", "-", ":", "/", "+", "$"]:

--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -27,11 +27,12 @@ load(
     "match_group_and_artifact",
     "strip_packaging_and_classifier",
     "strip_packaging_and_classifier_and_version",
+    "to_repository_name",
 )
 load("//private/lib:coordinates.bzl", "unpack_coordinates")
 
 def _genrule_copy_artifact_from_http_file(artifact, visibilities):
-    http_file_repository = escape(artifact["coordinates"])
+    http_file_repository = to_repository_name(artifact["coordinates"])
 
     file = artifact.get("out", artifact["file"])
 
@@ -146,7 +147,7 @@ copy_file(
     visibility = ["//visibility:public"],
 )""".format(
                 dylib = dylib,
-                repository = escape(artifact["coordinates"]),
+                repository = to_repository_name(artifact["coordinates"]),
             ),
         )
 
@@ -449,7 +450,7 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
             )
         elif packaging in ("exe", "json"):
             seen_imports[target_label] = True
-            versioned_target_alias_label = "%s_extension" % escape(artifact["coordinates"])
+            versioned_target_alias_label = "%s_extension" % to_repository_name(artifact["coordinates"])
             all_imports.append(
                 "alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n\tvisibility = [\"//visibility:public\"],\n)" % (target_label, versioned_target_alias_label),
             )

--- a/private/extensions/download_pinned_deps.bzl
+++ b/private/extensions/download_pinned_deps.bzl
@@ -1,4 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+load("//private:coursier_utilities.bzl", "to_repository_name")
 load("//private/lib:urls.bzl", "get_m2local_url")
 
 def escape(string):
@@ -10,7 +11,7 @@ def download_pinned_deps(mctx, artifacts, http_files, has_m2local):
     seen_repo_names = []
 
     for artifact in artifacts:
-        http_file_repository_name = escape(artifact["coordinates"])
+        http_file_repository_name = to_repository_name(artifact["coordinates"])
 
         if http_file_repository_name in http_files:
             continue

--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -7,6 +7,7 @@ load(
     "escape",
     "strip_packaging_and_classifier_and_version",
 )
+load("//private/lib:coordinates.bzl", "to_external_form")
 load("//private/rules:coursier.bzl", "DEFAULT_AAR_IMPORT_LABEL", "coursier_fetch", "pinned_coursier_fetch")
 load("//private/rules:unpinned_maven_pin_command_alias.bzl", "unpinned_maven_pin_command_alias")
 load("//private/rules:v1_lock_file.bzl", "v1_lock_file")
@@ -158,29 +159,11 @@ def _check_repo_name(repo_name_2_module_name, repo_name, module_name):
     known_names.append(module_name)
     repo_name_2_module_name[repo_name] = known_names
 
-def _to_maven_coords(artifact):
-    coords = "%s:%s" % (artifact.get("group"), artifact.get("artifact"))
-
-    extension = artifact.get("packaging", "jar")
-    if not extension:
-        extension = "jar"
-    classifier = artifact.get("classifier", "jar")
-    if not classifier:
-        classifier = "jar"
-
-    if classifier != "jar":
-        coords += ":%s:%s" % (extension, classifier)
-    elif extension != "jar":
-        coords += ":%s" % extension
-    coords += ":%s" % artifact.get("version")
-
-    return coords
-
 def _generate_compat_repos(name, existing_compat_repos, artifacts):
     seen = []
 
     for artifact in artifacts:
-        coords = _to_maven_coords(artifact)
+        coords = to_external_form(artifact)
         versionless = escape(strip_packaging_and_classifier_and_version(coords))
         if versionless in existing_compat_repos:
             continue

--- a/private/lib/coordinates.bzl
+++ b/private/lib/coordinates.bzl
@@ -101,6 +101,10 @@ def to_external_form(coords):
 
     if type(coords) == "string":
         unpacked = unpack_coordinates(coords)
+    elif type(coords) == "dict":
+        # Ensures that we have all the fields we expect to be present
+        fully_populated = {"version": None, "packaging": None, "classifier": None} | coords
+        unpacked = struct(**fully_populated)
     else:
         unpacked = coords
 

--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -17,8 +17,8 @@ load(
     "//private:coursier_utilities.bzl",
     "SUPPORTED_PACKAGING_TYPES",
     "contains_git_conflict_markers",
-    "escape",
     "is_maven_local_path",
+    "to_repository_name",
 )
 load("//private:dependency_tree_parser.bzl", "parser")
 load("//private:java_utilities.bzl", "build_java_argsfile_content")
@@ -587,7 +587,7 @@ def _pinned_coursier_fetch_impl(repository_ctx):
     netrc_entries = importer.get_netrc_entries(maven_install_json_content)
 
     for artifact in importer.get_artifacts(maven_install_json_content):
-        http_file_repository_name = escape(artifact["coordinates"])
+        http_file_repository_name = to_repository_name(artifact["coordinates"])
         if artifact.get("file"):
             maven_artifacts.extend([artifact["coordinates"]])
             http_files.extend([


### PR DESCRIPTION
The warning comes becomes we're attempting to migrate to the gradle external form for coordinates. However, much of the internal plumbing of the ruleset uses that format to pass information around.

This PR instead makes the values returned from the v2 lock file use the Gradle external form, and then wires through changes to allow things like the compat repos to continue to function.

I have not migrated the v1 lock file format, as I don't expect people to be using that with the most recent `rules_jvm_external` releases.

There are no additional tests, since if I got this wrong there would be catastrophic build failures here, and in client projects. There are no such catastrophic failures. He says, perhaps unwisely.