### PR TITLE
Remove the Windows `kt_jvm_export` example

### DIFF
--- a/.bazelci/examples.yml
+++ b/.bazelci/examples.yml
@@ -102,12 +102,12 @@ tasks:
     working_directory: examples/kt_jvm_export
     build_targets:
       - "//..."
-  kotlin-jvm-export-windows:
-    name: "kt_jvm_export example"
-    platform: windows
-    working_directory: examples/kt_jvm_export
-    build_targets:
-      - "//..."
+#  kotlin-jvm-export-windows:
+#    name: "kt_jvm_export example"
+#    platform: windows
+#    working_directory: examples/kt_jvm_export
+#    build_targets:
+#      - "//..."
   pom-file-generation-linux:
     name: "POM file generation example"
     platform: ubuntu1804


### PR DESCRIPTION
This has been failing for some time, and we've never understood why. Since none of the committers on the project have access to a Windows machine, and this is meant to be an example, it seems better to disable this build rather than have unfixable errors occur on people's PRs.