### PR TITLE
Uncomment failing gradle regression test

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -698,7 +698,7 @@ dev_maven.install(
     name = "regression_testing_gradle",
     artifacts = [
         # https://github.com/bazel-contrib/rules_jvm_external/issues/909
-        # "androidx.compose.foundation:foundation-layout:1.5.0-beta01",
+        "androidx.compose.foundation:foundation-layout:1.5.0-beta01",
         # https://github.com/bazel-contrib/rules_jvm_external/issues/909#issuecomment-2019217013
         "androidx.annotation:annotation:1.6.0",
     ],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -355,7 +355,7 @@ maven_install(
     name = "regression_testing_gradle",
     artifacts = [
         # https://github.com/bazel-contrib/rules_jvm_external/issues/909
-        # "androidx.compose.foundation:foundation-layout:1.5.0-beta01",
+        "androidx.compose.foundation:foundation-layout:1.5.0-beta01",
         # https://github.com/bazel-contrib/rules_jvm_external/issues/909#issuecomment-2019217013
         "androidx.annotation:annotation:1.6.0",
     ],

--- a/tests/bazel_run_tests.sh
+++ b/tests/bazel_run_tests.sh
@@ -284,13 +284,13 @@ function test_when_both_pom_and_jar_artifact_are_dependencies_jar_artifact_is_pr
   expect_log "@regression_testing_coursier//:org_mockito_mockito_core"
 }
 
-# function test_gradle_metadata_is_resolved_correctly_for_aar_artifact {
-#    # This artifact in maven_install only has gradle metadata, but it should then automatically resolve to the right aar artifact
-#    # and make it available
-#    bazel query @regression_testing_gradle//:androidx_compose_foundation_foundation_layout_android >> "$TEST_LOG" 2>&1
+function test_gradle_metadata_is_resolved_correctly_for_aar_artifact {
+   # This artifact in maven_install only has gradle metadata, but it should then automatically resolve to the right aar artifact
+   # and make it available
+   bazel query @regression_testing_gradle//:androidx_compose_foundation_foundation_layout_android >> "$TEST_LOG" 2>&1
 
-#    expect_log "@regression_testing_gradle//:androidx_compose_foundation_foundation_layout_android"
-# }
+   expect_log "@regression_testing_gradle//:androidx_compose_foundation_foundation_layout_android"
+}
 
 function test_gradle_metadata_is_resolved_correctly_for_jvm_artifact {
   # This artifact in maven_install only has gradle metadata, but it should then automatically resolve to the right jvm artifact
@@ -321,7 +321,7 @@ TESTS=(
   "test_transitive_dependency_with_type_of_pom"
   "test_when_both_pom_and_jar_artifact_are_available_jar_artifact_is_present"
   "test_when_both_pom_and_jar_artifact_are_dependencies_jar_artifact_is_present"
-  # "test_gradle_metadata_is_resolved_correctly_for_aar_artifact"
+  "test_gradle_metadata_is_resolved_correctly_for_aar_artifact"
   "test_gradle_metadata_is_resolved_correctly_for_jvm_artifact"
 )
 


### PR DESCRIPTION
Follow up to https://github.com/bazel-contrib/rules_jvm_external/pull/1385 to re-add gradle regression test that fails in CI