### PR TITLE
fail_if_repin_required is now True by default and minor improvement to failure message

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -95,7 +95,6 @@ maven.install(
         "org.gradle:gradle-tooling-api:%s" % _GRADLE_VERSION,
         "com.github.jknack:handlebars:4.3.1",
     ],
-    fail_if_repin_required = True,
     fetch_sources = True,
     lock_file = "//:rules_jvm_external_deps_install.json",
     repositories = [
@@ -477,7 +476,6 @@ dev_maven.install(
     boms = [
         "org.seleniumhq.selenium:selenium-bom:4.14.1",
     ],
-    fail_if_repin_required = True,
     lock_file = "@rules_jvm_external//tests/custom_maven_install:maven_resolved_install.json",
     repositories = [
         "https://repo.spring.io/plugins-release/",  # Requires auth, but we don't have it
@@ -633,7 +631,6 @@ dev_maven.install(
         # https://github.com/bazelbuild/rules_jvm_external/issues/1267
         "org.mockito:mockito-core:pom:3.3.3",
     ],
-    fail_if_repin_required = True,
     generate_compat_repositories = True,
     lock_file = "//tests/custom_maven_install:regression_testing_coursier_install.json",
     repositories = [
@@ -706,7 +703,6 @@ dev_maven.install(
     boms = [
         "io.opentelemetry:opentelemetry-bom:1.31.0",
     ],
-    fail_if_repin_required = True,
     generate_compat_repositories = True,
     lock_file = "//tests/custom_maven_install:regression_testing_maven_install.json",
     repin_instructions = "Please run `REPIN=1 bazel run @regression_testing_maven//:pin` to refresh the lock file.",
@@ -732,7 +728,6 @@ dev_maven.install(
         # https://github.com/bazel-contrib/rules_jvm_external/issues/909#issuecomment-2019217013
         "androidx.annotation:annotation:1.6.0",
     ],
-    fail_if_repin_required = True,
     generate_compat_repositories = True,
     lock_file = "//tests/custom_maven_install:regression_testing_gradle_install.json",
     repositories = [

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -289,7 +289,6 @@ maven_install(
             version = "1.3.13",
         ),
     ],
-    fail_if_repin_required = True,
     generate_compat_repositories = True,
     maven_install_json = "//tests/custom_maven_install:regression_testing_coursier_install.json",
     override_targets = {
@@ -334,7 +333,6 @@ maven_install(
     boms = [
         "io.opentelemetry:opentelemetry-bom:1.31.0",
     ],
-    fail_if_repin_required = True,
     generate_compat_repositories = True,
     maven_install_json = "//tests/custom_maven_install:regression_testing_maven_install.json",
     repin_instructions = "Please run `REPIN=1 bazel run @regression_testing_maven//:pin` to refresh the lock file.",
@@ -361,7 +359,6 @@ maven_install(
         # https://github.com/bazel-contrib/rules_jvm_external/issues/909#issuecomment-2019217013
         "androidx.annotation:annotation:1.6.0",
     ],
-    fail_if_repin_required = True,
     generate_compat_repositories = True,
     maven_install_json = "//tests/custom_maven_install:regression_testing_gradle_install.json",
     repin_instructions = "Please run `REPIN=1 bazel run @regression_testing_gradle//:pin` to refresh the lock file.",
@@ -972,7 +969,6 @@ maven_install(
     boms = [
         "com.google.cloud:libraries-bom:26.59.0",
     ],
-    fail_if_repin_required = True,
     maven_install_json = "@rules_jvm_external//tests/custom_maven_install:coursier_resolved_install.json",
     repositories = [
         "https://repo1.maven.org/maven2",
@@ -1011,7 +1007,6 @@ maven_install(
     boms = [
         "org.seleniumhq.selenium:selenium-bom:4.14.1",
     ],
-    fail_if_repin_required = True,
     maven_install_json = "@rules_jvm_external//tests/custom_maven_install:maven_resolved_install.json",
     repositories = [
         "https://repo.spring.io/plugins-release/",  # Requires auth, but we don't have it

--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -500,8 +500,6 @@ def _pinned_coursier_fetch_impl(repository_ctx):
     unpinned_pin_target = "@{}//:pin".format(unpinned_repo)
     pin_target = "@{}//:pin".format(user_provided_name)
 
-    repin_instructions = " REPIN=1 bazel run %s\n" % pin_target
-
     user_provided_repin_instructions = repository_ctx.attr.repin_instructions
     repin_instructions = user_provided_repin_instructions if user_provided_repin_instructions else (
         " REPIN=1 bazel run %s\n" % pin_target
@@ -530,7 +528,11 @@ def _pinned_coursier_fetch_impl(repository_ctx):
             )
         elif computed_artifacts_hash != input_artifacts_hash:
             if _get_fail_if_repin_required(repository_ctx):
-                fail("%s_install.json contains an invalid input signature and must be regenerated. " % (user_provided_name) +
+                fail("%s_install.json contains an invalid input signature (expected %s and got %s) and must be regenerated. " % (
+                         user_provided_name,
+                         input_artifacts_hash,
+                         computed_artifacts_hash,
+                     ) +
                      "This typically happens when the maven_install artifacts have been changed but not repinned. " +
                      "PLEASE DO NOT MODIFY THIS FILE DIRECTLY! To generate a new " +
                      "%s_install.json and re-pin the artifacts, please run:\n" % user_provided_name +

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -149,7 +149,6 @@ def rules_jvm_external_deps(
             "com.github.jknack:handlebars:4.3.1",
         ],
         maven_install_json = deps_lock_file,
-        fail_if_repin_required = True,
         strict_visibility = True,
         fetch_sources = True,
         repositories = repositories,


### PR DESCRIPTION
After https://github.com/bazel-contrib/rules_jvm_external/pull/1371 we can remove the `fail_if_repin_required = True` settings