### PR TITLE
Don't print warnings when testing utility functions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -356,7 +356,7 @@ dev_maven.install(
     name = "jvm_import_test",
     artifacts = [
         "com.google.code.findbugs:jsr305:3.0.2",
-        "com.android.support:appcompat-v7:aar:28.0.0",
+        "com.android.support:appcompat-v7:28.0.0@aar",
     ],
     repositories = [
         "https://repo1.maven.org/maven2",
@@ -605,7 +605,7 @@ dev_maven.install(
         "com.github.fommil.netlib:all:1.1.2",
         "nz.ac.waikato.cms.weka:weka-stable:3.8.1",
         # https://github.com/bazelbuild/rules_jvm_external/issues/111
-        "com.android.support:appcompat-v7:aar:28.0.0",
+        "com.android.support:appcompat-v7:28.0.0@aar",
         "com.google.android.gms:play-services-base:16.1.0",
         # https://github.com/bazelbuild/rules_jvm_external/issues/119#issuecomment-484278260
         "org.apache.flink:flink-test-utils_2.12:1.8.0",
@@ -638,14 +638,14 @@ dev_maven.install(
         # https://github.com/bazelbuild/rules_jvm_external/issues/917
         # androidx core-testing POM has "exclusion" for "byte-buddy" but it should be downloaded as mockito-core
         # dependency when the usually omitted "jar" packaging type is specified.
-        "org.mockito:mockito-core:jar:3.3.3",
-        "androidx.arch.core:core-testing:aar:2.1.0",
+        "org.mockito:mockito-core:3.3.3@jar",
+        "androidx.arch.core:core-testing:2.1.0@aar",
         # https://github.com/bazelbuild/rules_jvm_external/issues/1028
         "build.buf:protovalidate:0.1.9",
         # https://github.com/bazelbuild/rules_jvm_external/issues/1250
         "com.github.spotbugs:spotbugs:4.7.0",
         # https://github.com/bazelbuild/rules_jvm_external/issues/1267
-        "org.mockito:mockito-core:pom:3.3.3",
+        "org.mockito:mockito-core:3.3.3@pom",
     ],
     generate_compat_repositories = True,
     lock_file = "//tests/custom_maven_install:regression_testing_coursier_install.json",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -221,7 +221,7 @@ maven_install(
         "com.github.fommil.netlib:all:1.1.2",
         "nz.ac.waikato.cms.weka:weka-stable:3.8.1",
         # https://github.com/bazelbuild/rules_jvm_external/issues/111
-        "com.android.support:appcompat-v7:aar:28.0.0",
+        "com.android.support:appcompat-v7:28.0.0@aar",
         "com.google.android.gms:play-services-base:16.1.0",
         # https://github.com/bazelbuild/rules_jvm_external/issues/119#issuecomment-484278260
         "org.apache.flink:flink-test-utils_2.12:1.8.0",
@@ -269,14 +269,14 @@ maven_install(
         # https://github.com/bazelbuild/rules_jvm_external/issues/917
         # androidx core-testing POM has "exclusion" for "byte-buddy" but it should be downloaded as mockito-core
         # dependency when the usually omitted "jar" packaging type is specified.
-        "org.mockito:mockito-core:jar:3.3.3",
-        "androidx.arch.core:core-testing:aar:2.1.0",
+        "org.mockito:mockito-core:3.3.3@jar",
+        "androidx.arch.core:core-testing:2.1.0@aar",
         # https://github.com/bazelbuild/rules_jvm_external/issues/1028
         "build.buf:protovalidate:0.1.9",
         # https://github.com/bazelbuild/rules_jvm_external/issues/1250
         "com.github.spotbugs:spotbugs:4.7.0",
         # https://github.com/bazelbuild/rules_jvm_external/issues/1267
-        "org.mockito:mockito-core:pom:3.3.3",
+        "org.mockito:mockito-core:3.3.3@pom",
         # https://github.com/bazelbuild/rules_jvm_external/issues/1345
         maven.artifact(
             artifact = "jffi",

--- a/private/coursier_utilities.bzl
+++ b/private/coursier_utilities.bzl
@@ -58,8 +58,8 @@ def to_repository_name(coords):
 
     return escape(to_return)
 
-def _to_legacy_format(coord, include_version):
-    unpacked = unpack_coordinates(coord)
+def _to_legacy_format(coord, include_version, is_test = False):
+    unpacked = unpack_coordinates(coord, is_test = is_test)
 
     to_return = "%s:%s" % (unpacked.group, unpacked.artifact)
 
@@ -77,7 +77,7 @@ def _to_legacy_format(coord, include_version):
 
     return to_return
 
-def strip_packaging_and_classifier(coord):
+def strip_packaging_and_classifier(coord, is_test = False):
     # Strip some packaging and classifier values.
     #
     # We are expected to return one of:
@@ -86,10 +86,10 @@ def strip_packaging_and_classifier(coord):
     # groupId:artifactId:packaging:version
     # groupId:artifactId:packaging:classifier:version
 
-    return _to_legacy_format(coord, True)
+    return _to_legacy_format(coord, True, is_test = is_test)
 
-def strip_packaging_and_classifier_and_version(coord):
-    return _to_legacy_format(coord, False)
+def strip_packaging_and_classifier_and_version(coord, is_test = False):
+    return _to_legacy_format(coord, False, is_test = is_test)
 
 def match_group_and_artifact(source, target):
     source_coord = unpack_coordinates(source)

--- a/private/lib/coordinates.bzl
+++ b/private/lib/coordinates.bzl
@@ -16,7 +16,7 @@ SUPPORTED_PACKAGING_TYPES = [
     "test-jar",
 ]
 
-def unpack_coordinates(coords):
+def unpack_coordinates(coords, is_test = False):
     """Takes a maven coordinate and unpacks it into a struct with fields
     `group`, `artifact`, `version`, `packaging`, `classifier`
     where `version,` `packaging` and `classifier` may be `None`
@@ -82,7 +82,8 @@ def unpack_coordinates(coords):
             packaging = pieces[2]
             version = pieces[3]
             rewritten = "%s:%s:%s@%s" % (group, artifact, version, packaging)
-            print("Assuming %s should be interpreted as %s" % (coords, rewritten))
+            if not is_test:
+                print("Assuming %s should be interpreted as %s" % (coords, rewritten))
             return struct(group = group, artifact = artifact, packaging = packaging, version = version, classifier = None)
 
         # We could still be in one of `g:a:p:v` or `g:a:v:c`, but it's likely the latter. I do not

--- a/private/rules/maven_bom.bzl
+++ b/private/rules/maven_bom.bzl
@@ -78,7 +78,7 @@ def _maven_dependencies_bom_impl(ctx):
         ctx,
         coordinates = ctx.attr.maven_coordinates,
         is_bom = True,
-        versioned_dep_coordinates = combined_deps + ["%s:%s:pom:%s" % (unpacked.group, unpacked.artifact, unpacked.version)],
+        versioned_dep_coordinates = combined_deps + ["%s:%s:%s@pom" % (unpacked.group, unpacked.artifact, unpacked.version)],
         pom_template = ctx.file.pom_template,
         out_name = "%s.xml" % ctx.label.name,
         indent = 12,

--- a/private/rules/maven_utils.bzl
+++ b/private/rules/maven_utils.bzl
@@ -94,6 +94,8 @@ def generate_pom(
         substitutions.update({"{parent}": "".join(parts)})
 
     deps = []
+    # print("versioned_dep_coordinates = {}".format(versioned_dep_coordinates))
+    # print("unversioned_dep_coordinates = {}".format(unversioned_dep_coordinates))
     for dep in sorted(versioned_dep_coordinates) + sorted(unversioned_dep_coordinates):
         include_version = dep in versioned_dep_coordinates
         unpacked = _unpack_coordinates(dep)

--- a/private/rules/v1_lock_file.bzl
+++ b/private/rules/v1_lock_file.bzl
@@ -100,7 +100,7 @@ def _get_artifacts(lock_file_contents):
 
     return to_return
 
-def add_netrc_entries_from_mirror_urls(netrc_entries, mirror_urls):
+def add_netrc_entries_from_mirror_urls(netrc_entries, mirror_urls, is_test = False):
     """Add a url's auth credentials into a netrc dict of form return[machine][login] = password."""
     for url in mirror_urls:
         entry = extract_netrc_from_auth_url(url)
@@ -113,14 +113,16 @@ def add_netrc_entries_from_mirror_urls(netrc_entries, mirror_urls):
             netrc_entries[machine] = {}
         if login not in netrc_entries[machine]:
             if netrc_entries[machine]:
-                print("Received multiple logins for machine '{}'! Only using '{}'".format(
-                    machine,
-                    netrc_entries[machine].keys()[0],
-                ))
+                if not is_test:
+                    print("Received multiple logins for machine '{}'! Only using '{}'".format(
+                        machine,
+                        netrc_entries[machine].keys()[0],
+                    ))
                 continue
             netrc_entries[machine][login] = password
         elif netrc_entries[machine][login] != password:
-            print("Received different passwords for {}@{}! Only using the first".format(login, machine))
+            if not is_test:
+                print("Received different passwords for {}@{}! Only using the first".format(login, machine))
     return netrc_entries
 
 def _get_netrc_entries(lock_file_contents):

--- a/specs.bzl
+++ b/specs.bzl
@@ -126,11 +126,11 @@ def _parse_exclusion_spec_list(exclusion_specs):
         exclusions.append(exclusion_spec)
     return exclusions
 
-def _parse_maven_coordinate_string(mvn_coord):
+def _parse_maven_coordinate_string(mvn_coord, is_test = False):
     """
     Given a string containing a standard Maven coordinate (g:a:[p:[c:]]v) or gradle external dependency (g:a:v:c@p), returns a maven artifact map (see above).
     """
-    unpacked = unpack_coordinates(mvn_coord)
+    unpacked = unpack_coordinates(mvn_coord, is_test = is_test)
 
     # It would be nice to use `bazel_skylib//lib:structs.bzl` for this, but this file is
     # included from the `repositories.bzl` file, so skylib has not been loaded yet.

--- a/tests/unit/coordinates_test.bzl
+++ b/tests/unit/coordinates_test.bzl
@@ -42,7 +42,7 @@ complete_original_format_test = unittest.make(_complete_original_format_impl)
 def _original_format_omitting_scope_impl(ctx):
     env = unittest.begin(ctx)
 
-    unpacked = unpack_coordinates("group:artifact:test-jar:1.2.3")
+    unpacked = unpack_coordinates("group:artifact:test-jar:1.2.3", is_test = True)
     asserts.equals(env, "group", unpacked.group)
     asserts.equals(env, "artifact", unpacked.artifact)
     asserts.equals(env, "1.2.3", unpacked.version)
@@ -108,7 +108,7 @@ def _multiple_formats_impl(ctx):
     }
 
     for (coords, expected) in coords_to_structs.items():
-        unpacked = unpack_coordinates(coords)
+        unpacked = unpack_coordinates(coords, is_test = True)
         asserts.equals(env, expected, unpacked)
 
     return unittest.end(env)

--- a/tests/unit/coursier_test.bzl
+++ b/tests/unit/coursier_test.bzl
@@ -236,7 +236,7 @@ def _add_netrc_entries_from_mirror_urls_noop_test_impl(ctx):
     asserts.equals(
         env,
         {},
-        add_netrc_entries_from_mirror_urls({}, ["https://c1", "https://c1/something@there"]),
+        add_netrc_entries_from_mirror_urls({}, ["https://c1", "https://c1/something@there"], is_test = True),
     )
     return unittest.end(env)
 
@@ -247,7 +247,7 @@ def _add_netrc_entries_from_mirror_urls_basic_test_impl(ctx):
     asserts.equals(
         env,
         {"c1": {"a": "b"}},
-        add_netrc_entries_from_mirror_urls({}, ["https://a:b@c1"]),
+        add_netrc_entries_from_mirror_urls({}, ["https://a:b@c1"], is_test = True),
     )
     asserts.equals(
         env,
@@ -255,6 +255,7 @@ def _add_netrc_entries_from_mirror_urls_basic_test_impl(ctx):
         add_netrc_entries_from_mirror_urls(
             {"c1": {"a": "b"}},
             ["https://a:b@c1"],
+            is_test = True,
         ),
     )
     return unittest.end(env)
@@ -266,7 +267,7 @@ def _add_netrc_entries_from_mirror_urls_multi_login_ignored_test_impl(ctx):
     asserts.equals(
         env,
         {"c1": {"a": "b"}},
-        add_netrc_entries_from_mirror_urls({}, ["https://a:b@c1", "https://a:b2@c1", "https://a2:b3@c1"]),
+        add_netrc_entries_from_mirror_urls({}, ["https://a:b@c1", "https://a:b2@c1", "https://a2:b3@c1"], is_test = True),
     )
     asserts.equals(
         env,
@@ -274,6 +275,7 @@ def _add_netrc_entries_from_mirror_urls_multi_login_ignored_test_impl(ctx):
         add_netrc_entries_from_mirror_urls(
             {"c1": {"a": "b"}},
             ["https://a:b@c1", "https://a:b2@c1", "https://a2:b3@c1"],
+            is_test = True,
         ),
     )
     return unittest.end(env)
@@ -292,6 +294,7 @@ def _add_netrc_entries_from_mirror_urls_multi_case_test_impl(ctx):
         add_netrc_entries_from_mirror_urls(
             {"foo": {"bar": "baz"}},
             ["https://a1:b1@c1", "https://a2:b2@c2", "https://a:b@c1", "https://a:b2@c1", "https://a2:b3@c1"],
+            is_test = True,
         ),
     )
     return unittest.end(env)

--- a/tests/unit/coursier_utilities_test.bzl
+++ b/tests/unit/coursier_utilities_test.bzl
@@ -52,7 +52,7 @@ def _strip_packaging_and_classifier_test_impl(ctx):
     asserts.equals(
         env,
         "groupId:artifactId:1.2.3",
-        strip_packaging_and_classifier("groupId:artifactId:bundle:1.2.3"),
+        strip_packaging_and_classifier("groupId:artifactId:bundle:1.2.3", is_test = True),
     )
     asserts.equals(
         env,
@@ -75,7 +75,7 @@ def _strip_packaging_and_classifier_and_version_test_impl(ctx):
     asserts.equals(
         env,
         "groupId:artifactId",
-        strip_packaging_and_classifier_and_version("groupId:artifactId:bundle:1.2.3"),
+        strip_packaging_and_classifier_and_version("groupId:artifactId:bundle:1.2.3", is_test = True),
     )
     asserts.equals(
         env,

--- a/tests/unit/specs_test.bzl
+++ b/tests/unit/specs_test.bzl
@@ -69,7 +69,7 @@ def _parse_coordinate_test_impl(ctx):
     asserts.equals(
         env,
         {"group": "org.eclipse.aether", "artifact": "aether-api", "version": "1.1.0", "packaging": "jar", "classifier": None},
-        parse.parse_maven_coordinate("org.eclipse.aether:aether-api:jar:1.1.0"),
+        parse.parse_maven_coordinate("org.eclipse.aether:aether-api:jar:1.1.0", is_test = True),
     )
     asserts.equals(
         env,


### PR DESCRIPTION
Don't print test output for regular build.

```
bazel build //...

DEBUG: rules_jvm_external/private/lib/coordinates.bzl:85:18: Assuming com.android.support:appcompat-v7:aar:28.0.0 should be interpreted as com.android.support:appcompat-v7:28.0.0@aar
DEBUG: rules_jvm_external/private/lib/coordinates.bzl:85:18: Assuming com.android.support:appcompat-v7:aar:28.0.0 should be interpreted as com.android.support:appcompat-v7:28.0.0@aar
DEBUG: rules_jvm_external/private/lib/coordinates.bzl:85:18: Assuming org.mockito:mockito-core:jar:3.3.3 should be interpreted as org.mockito:mockito-core:3.3.3@jar
DEBUG: rules_jvm_external/private/lib/coordinates.bzl:85:18: Assuming androidx.arch.core:core-testing:aar:2.1.0 should be interpreted as androidx.arch.core:core-testing:2.1.0@aar
DEBUG: rules_jvm_external/private/lib/coordinates.bzl:85:18: Assuming org.mockito:mockito-core:pom:3.3.3 should be interpreted as org.mockito:mockito-core:3.3.3@pom
DEBUG: rules_jvm_external/private/lib/coordinates.bzl:85:18: Assuming group:artifact:test-jar:1.2.3 should be interpreted as group:artifact:1.2.3@test-jar
DEBUG: rules_jvm_external/private/lib/coordinates.bzl:85:18: Assuming groupId:artifactId:bundle:1.2.3 should be interpreted as groupId:artifactId:1.2.3@bundle
DEBUG: rules_jvm_external/private/lib/coordinates.bzl:85:18: Assuming org.eclipse.aether:aether-api:jar:1.1.0 should be interpreted as org.eclipse.aether:aether-api:1.1.0@jar
DEBUG: rules_jvm_external/private/rules/v1_lock_file.bzl:123:18: Received different passwords for a@c1! Only using the first
DEBUG: rules_jvm_external/private/rules/v1_lock_file.bzl:116:22: Received multiple logins for machine 'c1'! Only using 'a'
DEBUG: rules_jvm_external/private/rules/v1_lock_file.bzl:123:18: Received different passwords for a@c1! Only using the first
DEBUG: rules_jvm_external/private/rules/v1_lock_file.bzl:116:22: Received multiple logins for machine 'c1'! Only using 'a'
DEBUG: rules_jvm_external/private/rules/v1_lock_file.bzl:116:22: Received multiple logins for machine 'c1'! Only using 'a1'
DEBUG: rules_jvm_external/private/rules/v1_lock_file.bzl:116:22: Received multiple logins for machine 'c1'! Only using 'a1'
DEBUG: rules_jvm_external/private/rules/v1_lock_file.bzl:116:22: Received multiple logins for machine 'c1'! Only using 'a1'
DEBUG: rules_jvm_external/private/lib/coordinates.bzl:85:18: Assuming groupId:artifactId:test-jar:1.2.3 should be interpreted as groupId:artifactId:1.2.3@test-jar
DEBUG: rules_jvm_external/private/lib/coordinates.bzl:85:18: Assuming groupId:artifactId:bundle:1.2.3 should be interpreted as groupId:artifactId:1.2.3@bundle
```