### PR TITLE
[ci] At least one presubmit task should attempt to build everything

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -6,6 +6,8 @@ tasks:
       # https://github.com/bazelbuild/rules_jvm_external/pull/316
       COURSIER_CACHE: /tmp/custom_coursier_cache
       REPIN: 1
+    build_targets:
+      - "//..."
     shell_commands:
       - bazel run @regression_testing_coursier//:pin
       - bazel run @regression_testing_gradle//:pin


### PR DESCRIPTION
We've had several cases where we've needed to land additional PRs to fix things once they'd landed because we weren't building the entire repo.

We don't need to do this for our entire matrix of versions and OSs, but doing this in one place would be Really Nice.