### PR TITLE
Indicate which `install` tag has duplicate coordinates

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -285,11 +285,11 @@ dev_maven.artifact(
 )
 dev_maven.install(
     name = "from_files",
-    lock_file = "//tests/custom_maven_install:from_files_install.json",
     # This must be `True` to tickle a bug where requesting source jars caused
     # a missing dependency to be declared by accident in the generated build
     # file.
     fetch_sources = True,
+    lock_file = "//tests/custom_maven_install:from_files_install.json",
     repositories = [
         "https://repo1.maven.org/maven2",
         "https://maven.google.com",

--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -553,19 +553,23 @@ def maven_impl(mctx):
         # Special handling for artifacts and boms - deduplicate with root priority
         root_artifacts = root_repo.get("artifacts", [])
         non_root_artifacts = non_root_repo.get("artifacts", [])
-        merged_repo["artifacts"] = _deduplicate_artifacts_with_root_priority(
-            repo_name,
-            root_artifacts,
-            non_root_artifacts,
-        )
+        if repo_name in root_module_repos.keys():
+            merged_repo["artifacts"] = _deduplicate_artifacts_with_root_priority(
+                repo_name,
+                root_artifacts,
+                non_root_artifacts,
+            )
 
-        root_boms = root_repo.get("boms", [])
-        non_root_boms = non_root_repo.get("boms", [])
-        merged_repo["boms"] = _deduplicate_artifacts_with_root_priority(
-            repo_name,
-            root_boms,
-            non_root_boms,
-        )
+            root_boms = root_repo.get("boms", [])
+            non_root_boms = non_root_repo.get("boms", [])
+            merged_repo["boms"] = _deduplicate_artifacts_with_root_priority(
+                repo_name,
+                root_boms,
+                non_root_boms,
+            )
+        else:
+            merged_repo["artifacts"] = non_root_artifacts
+            merged_repo["boms"] = non_root_boms
 
         # For list attributes, concatenate but avoid duplicates (root items first)
         for list_attr in ["repositories", "excluded_artifacts", "additional_netrc_lines", "additional_coursier_options"]:

--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -553,6 +553,9 @@ def maven_impl(mctx):
         # Special handling for artifacts and boms - deduplicate with root priority
         root_artifacts = root_repo.get("artifacts", [])
         non_root_artifacts = non_root_repo.get("artifacts", [])
+        root_boms = root_repo.get("boms", [])
+        non_root_boms = non_root_repo.get("boms", [])
+
         if repo_name in root_module_repos.keys():
             merged_repo["artifacts"] = _deduplicate_artifacts_with_root_priority(
                 repo_name,
@@ -560,8 +563,6 @@ def maven_impl(mctx):
                 non_root_artifacts,
             )
 
-            root_boms = root_repo.get("boms", [])
-            non_root_boms = non_root_repo.get("boms", [])
             merged_repo["boms"] = _deduplicate_artifacts_with_root_priority(
                 repo_name,
                 root_boms,

--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -260,7 +260,7 @@ def _find_duplicate_artifacts_across_submodules(non_root_artifacts, root_maven_m
 
     return duplicates
 
-def _deduplicate_artifacts_with_root_priority(root_artifacts, non_root_artifacts):
+def _deduplicate_artifacts_with_root_priority(name, root_artifacts, non_root_artifacts):
     """Deduplicate artifacts, giving priority to root module artifacts."""
 
     # Collect maven modules from root artifacts (handle mixed types)
@@ -292,7 +292,7 @@ def _deduplicate_artifacts_with_root_priority(root_artifacts, non_root_artifacts
             else:
                 warning_parts.append(maven_module)
 
-        print("WARNING: The following maven modules appear in multiple sub-modules with potentially different versions. " +
+        print("WARNING: The following coordinates from `%s` appear in multiple sub-modules with potentially different versions. " % name +
               "Consider adding one of these to your root module to ensure consistent versions:\n\t%s" %
               "\n\t".join(sorted(warning_parts)))
 
@@ -554,6 +554,7 @@ def maven_impl(mctx):
         root_artifacts = root_repo.get("artifacts", [])
         non_root_artifacts = non_root_repo.get("artifacts", [])
         merged_repo["artifacts"] = _deduplicate_artifacts_with_root_priority(
+            repo_name,
             root_artifacts,
             non_root_artifacts,
         )
@@ -561,6 +562,7 @@ def maven_impl(mctx):
         root_boms = root_repo.get("boms", [])
         non_root_boms = non_root_repo.get("boms", [])
         merged_repo["boms"] = _deduplicate_artifacts_with_root_priority(
+            repo_name,
             root_boms,
             non_root_boms,
         )


### PR DESCRIPTION
And only do this for repos that are declared in the root module, as we don't want to worry about repos that are not in the root module.