### PR TITLE
Remove asc signatures on checksums in MavenPublisher

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/MavenPublisher.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/MavenPublisher.java
@@ -236,13 +236,6 @@ public class MavenPublisher {
     MavenSigning.SigningMethod signingMethod = signingMetadata.signingMethod;
     if (signingMethod.equals(MavenSigning.SigningMethod.GPG)) {
       uploads.add(upload(String.format("%s%s.asc", base, append), credentials, gpg_sign(item)));
-      uploads.add(upload(String.format("%s%s.md5.asc", base, append), credentials, gpg_sign(md5)));
-      uploads.add(
-          upload(String.format("%s%s.sha1.asc", base, append), credentials, gpg_sign(sha1)));
-      uploads.add(
-          upload(String.format("%s%s.sha256.asc", base, append), credentials, gpg_sign(sha256)));
-      uploads.add(
-          upload(String.format("%s%s.sha512.asc", base, append), credentials, gpg_sign(sha512)));
     } else if (signingMethod.equals(MavenSigning.SigningMethod.PGP)) {
       uploads.add(
           upload(
@@ -250,30 +243,6 @@ public class MavenPublisher {
               credentials,
               in_memory_pgp_sign(
                   item, signingMetadata.signingKey, signingMetadata.signingPassword)));
-      uploads.add(
-          upload(
-              String.format("%s%s.md5.asc", base, append),
-              credentials,
-              in_memory_pgp_sign(
-                  md5, signingMetadata.signingKey, signingMetadata.signingPassword)));
-      uploads.add(
-          upload(
-              String.format("%s%s.sha1.asc", base, append),
-              credentials,
-              in_memory_pgp_sign(
-                  sha1, signingMetadata.signingKey, signingMetadata.signingPassword)));
-      uploads.add(
-          upload(
-              String.format("%s%s.sha256.asc", base, append),
-              credentials,
-              in_memory_pgp_sign(
-                  sha256, signingMetadata.signingKey, signingMetadata.signingPassword)));
-      uploads.add(
-          upload(
-              String.format("%s%s.sha512.asc", base, append),
-              credentials,
-              in_memory_pgp_sign(
-                  sha512, signingMetadata.signingKey, signingMetadata.signingPassword)));
     }
 
     return CompletableFuture.allOf(uploads.toArray(new CompletableFuture<?>[0]));


### PR DESCRIPTION
It is neither necessary, nor correct to include `asc` signature files with checksums. See https://central.sonatype.org/publish/requirements/#sign-files-with-gpgpgp

Previously, uploading these files were simply a no-op. [But with Sonatype's recent migration to Central Publisher Portal](https://central.sonatype.org/pages/ossrh-eol/) -- it will result in a 500 error if these are uploaded:

```
Exception in thread "main" java.util.concurrent.ExecutionException: java.io.IOException: Unable to upload https://central.sonatype.com/repository/maven-snapshots/dev/cel/protobuf/0.10.1-TEST-SNAPSHOT/protobuf-0.10.1-TEST-SNAPSHOT.pom.md5.asc (500)
        at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
        at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2028)
        at com.github.bazelbuild.rules_jvm_external.maven.MavenPublisher.main(MavenPublisher.java:131)
Caused by: java.io.IOException: Unable to upload https://central.sonatype.com/repository/maven-snapshots/dev/cel/protobuf/0.10.1-TEST-SNAPSHOT/protobuf-0.10.1-TEST-SNAPSHOT.pom.md5.asc (500)
        at com.github.bazelbuild.rules_jvm_external.maven.MavenPublisher.lambda$httpUpload$3(MavenPublisher.java:337)
        at com.github.bazelbuild.rules_jvm_external.maven.MavenPublisher.lambda$upload$0(MavenPublisher.java:283)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```