### PR TITLE
set -XX:+ExitOnOutOfMemoryError when invoking coursier

### DIFF
--- a/private/rules/coursier.bzl
+++ b/private/rules/coursier.bzl
@@ -283,6 +283,8 @@ def _java_path(repository_ctx):
 def _generate_java_jar_command(repository_ctx, jar_path):
     coursier_opts = repository_ctx.os.environ.get("COURSIER_OPTS", "")
     coursier_opts = coursier_opts.split(" ") if len(coursier_opts) > 0 else []
+    # if coursier OOMs from a large dependency tree, have it crash instead of hanging
+    coursier_opts.append("-XX:+ExitOnOutOfMemoryError")
     java_path = _java_path(repository_ctx)
 
     if java_path != None:


### PR DESCRIPTION
We've run into some cases where `coursier fetch` will trigger an OutOfMemoryError and spin 100% of CPU doing useless garbage collection cycles on a very large input tree and where the amount of memory on the system running the pin command is not large enough, where the JVM is by default setting the max heap size to 25% of system memory.

This is easy enough to address by setting `COURSIER_OPTS`, but another thing we noticed along the way is that there is no trace of this OOM at all unless `RJE_VERBOSE` is set, since otherwise `--quiet` is passed to coursier. And since coursier isn't exiting on OOM, anyone running into this problem is stuck waiting for the `resolve_timeout` passed to `maven.install()`.

This patch adds the `-XX:ExitOnOutOfMemoryError` flag to `coursier_opts`, setting it unconditionally, to avoid the unnecessary waiting for the `repository_ctx.execute(...)` timeout to kick in.
