### PR TITLE
Maintain Starlark insertion order for repositories

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/lockfile/V2LockFile.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/lockfile/V2LockFile.java
@@ -259,8 +259,9 @@ public class V2LockFile {
     if (isUsingM2Local) {
       lock.put("m2local", true);
     }
-    // Use a treemap to sort the repo map by keys in the lock file
-    lock.put("repositories", new TreeMap<>(repos));
+    // repos is a LinkedHashSet which is iterated in insertion order.
+    // Meaning the order from the Stalark repositories array will be preserved.
+    lock.put("repositories", repos);
 
     lock.put("skipped", skipped);
     if (conflicts != null && !conflicts.isEmpty()) {


### PR DESCRIPTION
About a year ago `repositories` were changed to be lexicographically sorted in the lock file instead of maintaining insertion order. This happened here: https://github.com/bazel-contrib/rules_jvm_external/commit/2210745a6d6a36fd9f7815957c535e023ce4e625#diff-8c0518be6517159463b7482755f0cbecccc6f0abd1e86daf65c36e592da78ab8R121

That change took effect recently in 6.8 when the `private/tools/prebuilt/lock_file_converter_deploy.jar` file was updated: https://github.com/bazel-contrib/rules_jvm_external/commit/3034e39e2b8d460b8adb137834d88b06b6a44783#diff-98937dcc9d91f4310548d9ed8ce25c1f8b790e0f2bfa6158acbc043e9e620360

We ran into a problem after upgrading to 6.8 where we encountered a large number of 404s when fetching dependencies. We'd avoided this previously by putting `https://repo.maven.apache.org/maven2` ahead of all our other repositories in the `install` function call. Most of our dependencies are in that repo and it seems that repo used to be checked first.

The change to sort lexicographically resulted in lots of 404s because `repo.maven.apache.org` now comes last for us instead of first.

This change restores insertion order, so the order your `repositories` are in Starklark is the same order they are in the lockfile.

---

There is another part to this change where `private/tools/prebuilt/lock_file_converter_deploy.jar` needs to be updated.

I've verified this change works by building that jar with via `//private/tools/java/com/github/bazelbuild/rules_jvm_external/coursier:LockFileConverter_deploy.jar` and overriding our repo's `bazel_dep` to point to the updated version.

I'm not including that jar file in this commit. I'm happy to do so, but considering it is a binary, I imagine a maintainer will want to build and commit it.