### PR TITLE
Expose CreateJar as a rule

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -15,6 +15,7 @@
 load("//private:constants.bzl", _DEFAULT_REPOSITORY_NAME = "DEFAULT_REPOSITORY_NAME")
 load("//private/rules:artifact.bzl", _artifact = "artifact", _java_plugin_artifact = "java_plugin_artifact", _maven_artifact = "maven_artifact")
 load("//private/rules:has_maven_deps.bzl", _read_coordinates = "read_coordinates")
+load("//private/rules:jar.bzl", _create_jar = "create_jar")
 load("//private/rules:java_export.bzl", _java_export = "java_export", _maven_export = "maven_export")
 load("//private/rules:javadoc.bzl", _javadoc = "javadoc")
 load("//private/rules:maven_bom.bzl", _maven_bom = "maven_bom")
@@ -33,5 +34,6 @@ maven_artifact = _maven_artifact
 maven_bom = _maven_bom
 maven_install = _maven_install
 pom_file = _pom_file
+create_jar = _create_jar
 read_coordinates = _read_coordinates
 MavenPublishInfo = _MavenPublishInfo

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -22,6 +22,7 @@ stardoc(
     deps = [
         "//:implementation",
         "@bazel_skylib//lib:structs",
+        "@bazel_skylib//rules:run_binary",
     ],
 )
 

--- a/private/rules/jar.bzl
+++ b/private/rules/jar.bzl
@@ -1,0 +1,15 @@
+load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
+
+def create_jar(name, inputs, out = None):
+    if out == None:
+        out = name + ".jar"
+    elif not out.endswith(".jar"):
+        out = out + ".jar"
+
+    run_binary(
+        name = name,
+        srcs = inputs,
+        outs = [out],
+        tool = "@rules_jvm_external//private/tools/java/com/github/bazelbuild/rules_jvm_external/jar:CreateJar",
+        args = ["$(location %s)" % out] + ["$(location %s)" % i for i in inputs],
+    )

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/jar/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/jar/BUILD
@@ -59,3 +59,28 @@ java_binary(
         "//private/tools/java/com/github/bazelbuild/rules_jvm_external/zip",
     ],
 )
+
+java_library(
+    name = "create_jar_lib",
+    srcs = ["CreateJar.java"],
+    visibility = [
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/javadoc:__pkg__",
+        "//tests/com/github/bazelbuild/rules_jvm_external/jar:__pkg__",
+        "//tests/com/github/bazelbuild/rules_jvm_external/javadoc:__pkg__",
+    ],
+    deps = [
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external",
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/zip",
+    ],
+)
+
+java_binary(
+    name = "CreateJar",
+    main_class = "com.github.bazelbuild.rules_jvm_external.jar.CreateJar",
+    visibility = [
+        "//visibility:public",
+    ],
+    runtime_deps = [
+        ":create_jar_lib",
+    ],
+)

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/javadoc/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/javadoc/BUILD
@@ -7,8 +7,8 @@ java_library(
         "//tests/com/github/bazelbuild/rules_jvm_external/javadoc:__pkg__",
     ],
     deps = [
-        ":create_jar_lib",
         "//private/tools/java/com/github/bazelbuild/rules_jvm_external",
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/jar:create_jar_lib",
         "//private/tools/java/com/github/bazelbuild/rules_jvm_external/zip",
     ],
 )
@@ -21,17 +21,5 @@ java_binary(
     ],
     runtime_deps = [
         ":javadoc_lib",
-    ],
-)
-
-java_library(
-    name = "create_jar_lib",
-    srcs = ["CreateJar.java"],
-    visibility = [
-        "//tests/com/github/bazelbuild/rules_jvm_external/javadoc:__pkg__",
-    ],
-    deps = [
-        "//private/tools/java/com/github/bazelbuild/rules_jvm_external",
-        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/zip",
     ],
 )

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/javadoc/JavadocJarMaker.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/javadoc/JavadocJarMaker.java
@@ -21,7 +21,7 @@ import static java.lang.Runtime.Version;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.github.bazelbuild.rules_jvm_external.ByteStreams;
-import com.github.bazelbuild.rules_jvm_external.jar.CreateJar; // Added import after relocation
+import com.github.bazelbuild.rules_jvm_external.jar.CreateJar;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/javadoc/JavadocJarMaker.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/javadoc/JavadocJarMaker.java
@@ -21,6 +21,7 @@ import static java.lang.Runtime.Version;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.github.bazelbuild.rules_jvm_external.ByteStreams;
+import com.github.bazelbuild.rules_jvm_external.jar.CreateJar; // Added import after relocation
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/tests/com/github/bazelbuild/rules_jvm_external/jar/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/jar/BUILD
@@ -56,3 +56,19 @@ java_test(
         ),
     ],
 )
+
+java_test(
+    name = "CreateJarTest",
+    srcs = ["CreateJarTest.java"],
+    test_class = "com.github.bazelbuild.rules_jvm_external.jar.CreateJarTest",
+    deps = [
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external",
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/jar:create_jar_lib",
+        "//tests/com/github/bazelbuild/rules_jvm_external:zip_utils",
+        artifact("com.google.guava:guava"),
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing_coursier",
+        ),
+    ],
+)

--- a/tests/com/github/bazelbuild/rules_jvm_external/jar/CreateJarTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/jar/CreateJarTest.java
@@ -1,0 +1,49 @@
+package com.github.bazelbuild.rules_jvm_external.jar;
+
+import static com.github.bazelbuild.rules_jvm_external.ZipUtils.readJar;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class CreateJarTest {
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+  @Test
+  public void testCreateJar() throws Exception {
+    // Create temporary directory for test files
+    File tempDirFile = temp.newFolder("jar-test-input");
+    Path tempDir = tempDirFile.toPath();
+
+    // Create test files with known content
+    Path file1 = tempDir.resolve("file1.txt");
+    Files.writeString(file1, "content1");
+    Path subDir = tempDir.resolve("subdir");
+    Files.createDirectory(subDir);
+    Path file2 = subDir.resolve("file2.txt");
+    Files.writeString(file2, "content2");
+
+    // Create output jar path
+    Path outputJar = temp.newFile("output.jar").toPath();
+    ;
+    Files.delete(outputJar); // Delete so createJar can create it
+
+    CreateJar.main(
+        new String[] {outputJar.toAbsolutePath().toString(), tempDir.toAbsolutePath().toString()});
+
+    // Verify jar was created
+    assertTrue(Files.exists(outputJar));
+
+    // Verify jar contents
+    Map<String, String> jarContents = readJar(outputJar);
+    assertEquals("content1", jarContents.get("file1.txt"));
+    assertEquals("content2", jarContents.get("subdir/file2.txt"));
+  }
+}


### PR DESCRIPTION
In Confluent's fork of rules_jvm_external, we have a `scala_export` macro that utilizes the `CreateJar` tool. It was decided that the scala_export macro wouldn't be [upstreamed](https://github.com/bazel-contrib/rules_jvm_external/pull/1257) here. So I am reimplementing it in `rules_scala` and it needs this utility for creating the [scaladocs](https://github.com/bazel-contrib/rules_scala/compare/master...confluentinc:rules_scala:vinnybod/upstream-scala-export#diff-aab783120e43fe84f1484d1bd0222296feaf64a3e2314c60aad81a8277a7e0a9R110-R114) jar.

If we don't want to expose this utility publicly in rules_jvm_external, then I can just copy this file to the rules_scala change.