### PR TITLE
Upload checksums only after artifact succeeds

### DIFF
--- a/tests/com/github/bazelbuild/rules_jvm_external/maven/MavenPublisherTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/maven/MavenPublisherTest.java
@@ -11,6 +11,8 @@ import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.Test;
@@ -88,6 +90,86 @@ public class MavenPublisherTest {
         jar.getAbsolutePath(),
         true,
         "test=" + testJar.getAbsolutePath() + ",javadoc=" + docsJar.getAbsolutePath(),
+        "http://localhost:" + server.getAddress().getPort() + "/repository",
+        null,
+        SigningMetadata.noSigner(),
+        executor);
+    executor.shutdown();
+    server.stop(0);
+
+    Path repoRoot = root.resolve("repository/com/example/example/1.0.0");
+    assertTrue(Files.exists(repoRoot.resolve("example-1.0.0.pom")));
+    assertTrue(Files.exists(repoRoot.resolve("example-1.0.0.pom.md5")));
+    assertTrue(Files.exists(repoRoot.resolve("example-1.0.0.pom.sha1")));
+    assertTrue(Files.exists(repoRoot.resolve("example-1.0.0.jar")));
+    assertTrue(Files.exists(repoRoot.resolve("example-1.0.0.jar.md5")));
+    assertTrue(Files.exists(repoRoot.resolve("example-1.0.0.jar.sha1")));
+  }
+
+  @Test
+  public void testChecksumsUploadedOnlyAfterArtifact() throws Exception {
+    final Path root = Paths.get(System.getenv("TEST_TMPDIR"));
+    final Set<String> uploadedArtifacts = new HashSet<>();
+
+    HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+    server.createContext(
+        "/",
+        ex -> {
+          String method = ex.getRequestMethod();
+          Path target = root.resolve("." + ex.getRequestURI().getPath()).normalize();
+          String requestPath = ex.getRequestURI().getPath();
+
+          if ("PUT".equals(method)) {
+            // Checksums (md5, sha1, sha256, sha512) should only succeed if the artifact itself has
+            // been uploaded
+            boolean isChecksum = requestPath.endsWith(".md5") || requestPath.endsWith(".sha1")
+                || requestPath.endsWith(".sha256") || requestPath.endsWith(".sha512");
+            boolean isArtifact = requestPath.endsWith(".jar") || requestPath.endsWith(".pom");
+
+            if (isChecksum) {
+              // Extract the base artifact name (without checksum extension)
+              String artifactName = requestPath.replaceAll("\\.(md5|sha1|sha256|sha512)$", "");
+              if (!uploadedArtifacts.contains(artifactName)) {
+                // Simulate CodeArtifact behavior: 404 if artifact not yet indexed
+                ex.sendResponseHeaders(404, -1);
+                ex.close();
+                return;
+              }
+            }
+
+            if (isArtifact) {
+              uploadedArtifacts.add(requestPath);
+            }
+
+            Files.createDirectories(target.getParent());
+            try (InputStream in = ex.getRequestBody();
+                OutputStream out = Files.newOutputStream(target)) {
+              in.transferTo(out);
+            }
+            ex.sendResponseHeaders(201, 0);
+          } else if ("GET".equals(method) && Files.exists(target)) {
+            byte[] data = Files.readAllBytes(target);
+            ex.sendResponseHeaders(200, data.length);
+            try (OutputStream out = ex.getResponseBody()) {
+              out.write(data);
+            }
+          } else {
+            ex.sendResponseHeaders(404, -1);
+          }
+          ex.close();
+        });
+    server.start();
+
+    File pom = File.createTempFile("pom", ".xml");
+    File jar = File.createTempFile("example-project", ".jar");
+
+    ExecutorService executor = Executors.newFixedThreadPool(4);
+    MavenPublisher.run(
+        "com.example:example:1.0.0",
+        pom.getAbsolutePath(),
+        jar.getAbsolutePath(),
+        true,
+        null,
         "http://localhost:" + server.getAddress().getPort() + "/repository",
         null,
         SigningMetadata.noSigner(),


### PR DESCRIPTION
CodeArtifact [returns](https://docs.aws.amazon.com/codeartifact/latest/ug/maven-checksums.html#maven-checksum-mismatch) HTTP/404 when uploading checksums for artifacts that haven't been indexed yet. Change the upload flow to wait for the artifact upload to complete before uploading checksums (MD5, SHA1, SHA256, SHA512), ensuring the artifact is available before its checksums are posted.

Checksums are still uploaded in parallel with each other after the artifact succeeds.