### PR TITLE
Fix resolver BOM force versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -967,6 +967,7 @@ dev_maven.install(
     ],
     known_contributing_modules = [
         "root_wins_layer",
+        "root_wins_layer_two",
         "rules_jvm_external",
     ],
     lock_file = "//tests/custom_maven_install:root_wins_install.json",
@@ -979,9 +980,16 @@ dev_maven.amend_artifact(
 )
 
 bazel_dep(name = "root_wins_layer", version = "0.0.0", dev_dependency = True)
+bazel_dep(name = "root_wins_layer_two", version = "0.0.0", dev_dependency = True)
+
 local_path_override(
     module_name = "root_wins_layer",
     path = "tests/integration/root_wins_layer",
+)
+
+local_path_override(
+    module_name = "root_wins_layer_two",
+    path = "tests/integration/root_wins_layer_two",
 )
 
 dev_maven.install(
@@ -1115,15 +1123,15 @@ use_repo(
 
     # Final entries
     "com_google_http_client_google_http_client",
+    "legacy_multi_repo_hash",
+    "multi_repo_hash",
     "root_wins",
     "testonly_testing",
+    "unpinned_legacy_multi_repo_hash",
+    "unpinned_multi_repo_hash",
     "unpinned_v1_lock_file_format",
     "v1_lock_file_format",
     "version_interval_testing",
-    "multi_repo_hash",
-    "unpinned_multi_repo_hash",
-    "legacy_multi_repo_hash",
-    "unpinned_legacy_multi_repo_hash",
 )
 
 http_file(

--- a/private/extensions/maven.bzl
+++ b/private/extensions/maven.bzl
@@ -25,6 +25,11 @@ DEFAULT_NAME = "maven"
 
 _DEFAULT_RESOLVER = "coursier"
 
+_DEPENDENCY_BUCKETS = [
+    ("artifacts", "bazel_dep_to_artifacts", "artifacts"),
+    ("boms", "bazel_dep_to_boms", "BOMs"),
+]
+
 artifact = tag_class(
     doc = "Used to define a single artifact where the simple coordinates are insufficient. Will be added to the other artifacts declared by tags with the same `name` attribute.",
     attrs = {
@@ -144,10 +149,10 @@ from_toml = tag_class(
 )
 
 amend_artifact = tag_class(
-    doc = "Modifies an artifact with `coordinates` defined in other tags with additional properties.",
+    doc = "Modifies an artifact or BOM with `coordinates` defined in other tags with additional properties.",
     attrs = {
         "name": attr.string(default = DEFAULT_NAME),
-        "coordinates": attr.string(doc = "Coordinates of the artifact to amend. Only `group:artifact` are used for matching.", mandatory = True),
+        "coordinates": attr.string(doc = "Coordinates of the artifact or BOM to amend. Only `group:artifact` are used for matching.", mandatory = True),
         "force_version": attr.string(values = ["on", "off", "true", "false", ""], default = ""),
         "neverlink": attr.string(values = ["on", "off", "true", "false", ""], default = ""),
         "testonly": attr.string(values = ["on", "off", "true", "false", ""], default = ""),
@@ -179,9 +184,12 @@ def _add_exclusions(exclusions):
             to_return.append(exclusion)
     return to_return
 
-def _warn_if_multiple_contributing_modules(repo, repo_name, non_root_bazel_dep_to_artifacts):
+def _contributing_module_names(bazel_dep_to_non_root_artifacts, bazel_dep_to_non_root_boms):
+    return {name: True for name in bazel_dep_to_non_root_artifacts.keys() + bazel_dep_to_non_root_boms.keys()}.keys()
+
+def _warn_if_multiple_contributing_modules(repo, repo_name, non_root_bazel_dep_to_artifacts, non_root_bazel_dep_to_boms):
     known_contributing_modules = repo.get("known_contributing_modules", sets.make())
-    contributing_module_names = non_root_bazel_dep_to_artifacts.keys()
+    contributing_module_names = _contributing_module_names(non_root_bazel_dep_to_artifacts, non_root_bazel_dep_to_boms)
     new_contributing_modules = sets.difference(sets.make(contributing_module_names), known_contributing_modules)
     if sets.length(new_contributing_modules) > 0:
         print("The maven repository '%s' has contributions from multiple bzlmod modules, and will be resolved together: %s." % (
@@ -215,67 +223,168 @@ def _generate_compat_repos(name, existing_compat_repos, artifacts):
 
     return seen
 
-def _deduplicate_non_root_artifacts(bazel_dep_to_non_root_artifacts, return_only_artifacts = False):
-    coordinate_to_artifact = {}
-    for bazel_dep_name in bazel_dep_to_non_root_artifacts:
-        for artifact in bazel_dep_to_non_root_artifacts.get(bazel_dep_name, []):
-            if not getattr(artifact, "testonly", False):
-                artifact_key = to_key(artifact)
+def _dependency_label(dependency):
+    return "%s:%s" % (dependency.group, dependency.artifact)
 
-                # prioritize highest version
-                if artifact_key in coordinate_to_artifact:
-                    _bazel_dep_name, current_artifact = coordinate_to_artifact[artifact_key]
-                    if compare_maven_versions(current_artifact.version, artifact.version) == -1:
-                        coordinate_to_artifact[artifact_key] = (bazel_dep_name, artifact)
+def _fail_forced_version_conflict(current_dependency, next_dependency, current_source, next_source, dependency_kind):
+    if current_dependency.version == next_dependency.version:
+        return
+
+    fail("Conflicting forced versions for %s '%s': %s from %s and %s from %s" % (
+        dependency_kind,
+        _dependency_label(current_dependency),
+        current_dependency.version,
+        current_source,
+        next_dependency.version,
+        next_source,
+    ))
+
+def _is_forced_dependency(dependency, pinned_policy = False):
+    # Keep pinned policy as merge-time behavior so existing lock input hashes
+    # do not change by synthesizing force_version fields.
+    return pinned_policy or getattr(dependency, "force_version", False)
+
+def _should_replace_dependency(
+        current_dependency,
+        next_dependency,
+        current_source,
+        next_source,
+        dependency_kind,
+        current_pinned_policy = False,
+        next_pinned_policy = False):
+    current_forced = _is_forced_dependency(current_dependency, current_pinned_policy)
+    next_forced = _is_forced_dependency(next_dependency, next_pinned_policy)
+
+    if current_forced and next_forced:
+        _fail_forced_version_conflict(current_dependency, next_dependency, current_source, next_source, dependency_kind)
+        return False
+
+    if current_forced != next_forced:
+        return next_forced
+
+    return compare_maven_versions(current_dependency.version, next_dependency.version) == -1
+
+def _deduplicate_non_root_dependencies(
+        bazel_dep_to_non_root_dependencies,
+        dependency_kind,
+        return_only_dependencies = False,
+        root_forced_dependency_keys = None,
+        pinned_policy = False):
+    root_forced_dependency_keys = root_forced_dependency_keys or {}
+    coordinate_to_dependency = {}
+    for bazel_dep_name in bazel_dep_to_non_root_dependencies:
+        for dependency in bazel_dep_to_non_root_dependencies.get(bazel_dep_name, []):
+            if not getattr(dependency, "testonly", False):
+                dependency_key = to_key(dependency)
+
+                # Prioritize forced versions, then the highest version.
+                if dependency_key in coordinate_to_dependency:
+                    current_bazel_dep_name, current_dependency = coordinate_to_dependency[dependency_key]
+                    if dependency_key in root_forced_dependency_keys:
+                        # The root module's forced version wins, so conflicting
+                        # non-root forced versions for this coordinate are ignored.
+                        continue
+                    elif _should_replace_dependency(
+                        current_dependency,
+                        dependency,
+                        current_bazel_dep_name,
+                        bazel_dep_name,
+                        dependency_kind,
+                        current_pinned_policy = pinned_policy,
+                        next_pinned_policy = pinned_policy,
+                    ):
+                        coordinate_to_dependency[dependency_key] = (bazel_dep_name, dependency)
                 else:
-                    coordinate_to_artifact[artifact_key] = (bazel_dep_name, artifact)
+                    coordinate_to_dependency[dependency_key] = (bazel_dep_name, dependency)
 
-    if return_only_artifacts:
-        return [v[1] for v in coordinate_to_artifact.values()]
+    if return_only_dependencies:
+        return [v[1] for v in coordinate_to_dependency.values()]
     else:
-        return coordinate_to_artifact
+        return coordinate_to_dependency
+
+def _forced_dependency_keys(dependencies, pinned_policy = False):
+    return {
+        to_key(dependency): True
+        for dependency in dependencies
+        if _is_forced_dependency(dependency, pinned_policy)
+    }
+
+def _fail_if_root_has_conflicting_forced_dependencies(root_dependencies, dependency_kind, pinned_policy = False):
+    forced_dependencies = {}
+    for dependency in root_dependencies:
+        if not _is_forced_dependency(dependency, pinned_policy):
+            continue
+
+        dependency_key = to_key(dependency)
+        if dependency_key in forced_dependencies:
+            _fail_forced_version_conflict(forced_dependencies[dependency_key], dependency, "the root module", "the root module", dependency_kind)
+        else:
+            forced_dependencies[dependency_key] = dependency
 
 # Each bzlmod module may contribute jars to different rules_jvm_external maven repo namespaces.
 # We emit a warning to the user if a module overrides an artifact version in the root maven repo.
 #
 # This can be typical for the default @maven namespace, if a bzlmod dependency
 # wishes to contribute to the users' jars.
-def _deduplicate_artifacts_with_root_priority(name, root_artifacts, bazel_dep_to_non_root_artifacts, repin_env_var, rje_verbose_env_var):
-    """Deduplicate artifacts, giving priority to root module artifacts with force_version set."""
-    non_root_coordinate_to_artifact = _deduplicate_non_root_artifacts(bazel_dep_to_non_root_artifacts)
+def _deduplicate_dependencies_with_root_priority(
+        name,
+        root_dependencies,
+        bazel_dep_to_non_root_dependencies,
+        repin_env_var,
+        rje_verbose_env_var,
+        dependency_kind,
+        root_pinned_policy = False,
+        non_root_pinned_policy = False):
+    """Deduplicate dependencies, giving priority to forced root module dependencies."""
+    _fail_if_root_has_conflicting_forced_dependencies(root_dependencies, dependency_kind, pinned_policy = root_pinned_policy)
+    root_forced_dependency_keys = _forced_dependency_keys(root_dependencies, pinned_policy = root_pinned_policy)
 
-    duplicate_artifact_warning = ""
-    filtered_non_root_artifacts = []
-    for root_artifact in root_artifacts:
-        artifact_key = to_key(root_artifact)
-        if artifact_key in non_root_coordinate_to_artifact:
-            bazel_dep_name, non_root_artifact = non_root_coordinate_to_artifact.pop(artifact_key)
-            if not getattr(root_artifact, "force_version", False):
-                # prioritize highest version
-                if compare_maven_versions(root_artifact.version, non_root_artifact.version) == -1:
-                    filtered_non_root_artifacts.append(non_root_artifact)
-                    duplicate_artifact_warning = duplicate_artifact_warning + (
-                        "\nWARNING: For dependency '%s:%s' the root @%s repo wants version %s, " % (root_artifact.group, root_artifact.artifact, name, root_artifact.version) +
-                        "but got %s from the %s bazel dep. " % (non_root_artifact.version, bazel_dep_name) +
+    non_root_coordinate_to_dependency = _deduplicate_non_root_dependencies(
+        bazel_dep_to_non_root_dependencies,
+        dependency_kind,
+        root_forced_dependency_keys = root_forced_dependency_keys,
+        pinned_policy = non_root_pinned_policy,
+    )
+
+    duplicate_dependency_warning = ""
+    filtered_non_root_dependencies = []
+    for root_dependency in root_dependencies:
+        dependency_key = to_key(root_dependency)
+        if dependency_key in non_root_coordinate_to_dependency:
+            bazel_dep_name, non_root_dependency = non_root_coordinate_to_dependency.pop(dependency_key)
+            if not _is_forced_dependency(root_dependency, root_pinned_policy):
+                if _should_replace_dependency(
+                    root_dependency,
+                    non_root_dependency,
+                    "the root module",
+                    bazel_dep_name,
+                    dependency_kind,
+                    current_pinned_policy = root_pinned_policy,
+                    next_pinned_policy = non_root_pinned_policy,
+                ):
+                    filtered_non_root_dependencies.append(non_root_dependency)
+                    duplicate_dependency_warning = duplicate_dependency_warning + (
+                        "\nWARNING: For %s '%s:%s' the root @%s repo wants version %s, " % (dependency_kind, root_dependency.group, root_dependency.artifact, name, root_dependency.version) +
+                        "but got %s from the %s bazel dep. " % (non_root_dependency.version, bazel_dep_name) +
                         "Please update the version in your MODULE.bazel or set `force_version = True`."
                     )
 
-    # Add any remaining non root artifacts that weren't found in the root artifact list
-    addtional_artifact_message = ""
-    for bazel_dep_name, non_root_artifact in non_root_coordinate_to_artifact.values():
-        addtional_artifact_message = addtional_artifact_message + (
-            "\nINFO: The @%s repo is getting the additional artifact %s:%s:%s from the %s bazel dep." % (name, non_root_artifact.group, non_root_artifact.artifact, non_root_artifact.version, bazel_dep_name)
+    # Add any remaining non-root dependencies that weren't found in the root dependency list.
+    additional_dependency_message = ""
+    for bazel_dep_name, non_root_dependency in non_root_coordinate_to_dependency.values():
+        additional_dependency_message = additional_dependency_message + (
+            "\nINFO: The @%s repo is getting the additional %s %s:%s:%s from the %s bazel dep." % (name, dependency_kind, non_root_dependency.group, non_root_dependency.artifact, non_root_dependency.version, bazel_dep_name)
         )
-        filtered_non_root_artifacts.append(non_root_artifact)
+        filtered_non_root_dependencies.append(non_root_dependency)
 
     if repin_env_var:
-        if duplicate_artifact_warning != "":
-            print(duplicate_artifact_warning)
+        if duplicate_dependency_warning != "":
+            print(duplicate_dependency_warning)
         if rje_verbose_env_var:
-            if addtional_artifact_message != "":
-                print(addtional_artifact_message)
+            if additional_dependency_message != "":
+                print(additional_dependency_message)
 
-    return root_artifacts + filtered_non_root_artifacts
+    return root_dependencies + filtered_non_root_dependencies
 
 def _get_tri_state_bool(amend_val, original_val):
     if amend_val in ["true", "on"]:
@@ -314,6 +423,15 @@ def _coordinates_match(artifact, coordinates):
     return (artifact.group == coords.group and
             artifact.artifact == coords.artifact)
 
+def _apply_amendment_to_dependencies(amend, dependency_collections):
+    amended = False
+    for dependencies in dependency_collections:
+        for i, dependency in enumerate(dependencies):
+            if _coordinates_match(dependency, amend.coordinates):
+                dependencies[i] = _amend_artifact(dependency, amend)
+                amended = True
+    return amended
+
 def apply_amendment(amend, artifacts, boms):
     """Applies an `amend_artifact` to matching entries in `artifacts` and `boms`.
 
@@ -330,13 +448,29 @@ def apply_amendment(amend, artifacts, boms):
     Returns:
         `True` if at least one artifact or BOM matched the amendment.
     """
-    amended = False
-    for collection in (artifacts, boms):
-        for i, entry in enumerate(collection):
-            if _coordinates_match(entry, amend.coordinates):
-                collection[i] = _amend_artifact(entry, amend)
-                amended = True
-    return amended
+    return _apply_amendment_to_dependencies(amend, [artifacts, boms])
+
+def _dependency_from_gradle_version_entry(coords, value):
+    dependency = unpack_coordinates(coords)
+
+    if type(value) != "dict":
+        return dependency
+
+    dependency_dict = {
+        "group": dependency.group,
+        "artifact": dependency.artifact,
+        "version": getattr(dependency, "version", None),
+        "packaging": getattr(dependency, "packaging", None),
+        "classifier": getattr(dependency, "classifier", None),
+    }
+    if "classifier" in value.keys():
+        dependency_dict["classifier"] = value["classifier"]
+    if "exclusions" in value.keys():
+        dependency_dict["exclusions"] = _add_exclusions(json.decode(value["exclusions"].replace("'", '"')))
+    if "force_version" in value.keys():
+        dependency_dict["force_version"] = (value["force_version"].lower() == "true")
+
+    return struct(**dependency_dict)
 
 def process_gradle_versions_file(parsed, bom_modules):
     artifacts = []
@@ -394,29 +528,12 @@ def process_gradle_versions_file(parsed, bom_modules):
         module_id = coords.split(":")[0] + ":" + coords.split(":")[1] if ":" in coords else coords
 
         is_bom = type(value) == "dict" and value.get("is_bom", "false").lower() == "true"
+        dependency = _dependency_from_gradle_version_entry(coords, value)
 
         if is_bom or module_id in bom_modules:
-            boms.append(unpack_coordinates(coords))
+            boms.append(dependency)
         else:
-            artifact = unpack_coordinates(coords)
-
-            if type(value) == "dict":
-                artifact_dict = {
-                    "group": artifact.group,
-                    "artifact": artifact.artifact,
-                    "version": getattr(artifact, "version", None),
-                    "packaging": getattr(artifact, "packaging", None),
-                    "classifier": getattr(artifact, "classifier", None),
-                }
-                if "classifier" in value.keys():
-                    artifact_dict["classifier"] = value["classifier"]
-                if "exclusions" in value.keys():
-                    artifact_dict["exclusions"] = _add_exclusions(json.decode(value["exclusions"].replace("'", '"')))
-                if "force_version" in value.keys():
-                    artifact_dict["force_version"] = (value["force_version"].lower() == "true")
-                artifact = struct(**artifact_dict)
-
-            artifacts.append(artifact)
+            artifacts.append(dependency)
 
     return artifacts, boms
 
@@ -439,6 +556,27 @@ def _add_boms_to_repo(repo, mod, new_boms):
             repo["bazel_dep_to_boms"] = {}
         boms = repo["bazel_dep_to_boms"].get(mod.name, [])
         repo["bazel_dep_to_boms"][mod.name] = boms + new_boms
+
+def _get_dependencies_for_module(repo, mod, root_key, non_root_key):
+    if mod.is_root:
+        return repo.get(root_key, [])
+
+    return repo.get(non_root_key, {}).get(mod.name, [])
+
+def _filter_known_contributing_modules(repo_name, dependency_kind, bazel_dep_to_non_root_dependencies, known_contributing_modules, rje_verbose_env_var):
+    all_non_root_modules = bazel_dep_to_non_root_dependencies.keys()
+    filtered = {
+        k: bazel_dep_to_non_root_dependencies[k]
+        for k in sets.to_list(known_contributing_modules)
+        if k in bazel_dep_to_non_root_dependencies
+    }
+
+    if rje_verbose_env_var:
+        for k in all_non_root_modules:
+            if k not in filtered.keys():
+                print("\nINFO: The @%s repo is not using %s from %s because it is not in the known_contributing_modules" % (repo_name, dependency_kind, k))
+
+    return filtered
 
 def _process_module_tags(mctx):
     """Process artifact and install tags for a single module."""
@@ -550,21 +688,12 @@ def _process_module_tags(mctx):
         # Process amend_artifact tags
         for amend in mod.tags.amend_artifact:
             repo = target_repos.get(amend.name, {})
-            if mod.is_root:
-                artifacts = repo.get("artifacts", [])
-                boms = repo.get("boms", [])
-            else:
-                if not "bazel_dep_to_artifacts" in repo:
-                    repo["bazel_dep_to_artifacts"] = {}
-                artifacts = repo["bazel_dep_to_artifacts"].get(mod.name, [])
-                if not "bazel_dep_to_boms" in repo:
-                    repo["bazel_dep_to_boms"] = {}
-                boms = repo["bazel_dep_to_boms"].get(mod.name, [])
-
-            # Amend matching artifacts and BOMs.
-            if not apply_amendment(amend, artifacts, boms):
-                # If no matching artifact found, this might be an error or we could create a placeholder
-                fail("No artifact found matching coordinates '%s' for amendment" % amend.coordinates)
+            dependency_collections = [
+                _get_dependencies_for_module(repo, mod, root_key, non_root_key)
+                for root_key, non_root_key, _dependency_kind in _DEPENDENCY_BUCKETS
+            ]
+            if not _apply_amendment_to_dependencies(amend, dependency_collections):
+                fail("No artifact or BOM found matching coordinates '%s' for amendment" % amend.coordinates)
 
     return root_module_repos, non_root_module_repos
 
@@ -640,58 +769,71 @@ def maven_impl(mctx):
         merged_repo.update(non_root_repo)
         merged_repo.update(root_repo)
 
-        # Special handling for artifacts and boms - deduplicate with root priority
+        # Artifacts and BOMs are kept in separate buckets because they are passed
+        # separately to the resolvers, but their module-merging rules are the same.
         root_artifacts = root_repo.get("artifacts", [])
         bazel_dep_to_non_root_artifacts = non_root_repo.get("bazel_dep_to_artifacts", {})
         root_boms = root_repo.get("boms", [])
         bazel_dep_to_non_root_boms = non_root_repo.get("bazel_dep_to_boms", {})
+        root_pinned_policy = root_repo.get("version_conflict_policy") == "pinned"
+        non_root_pinned_policy = non_root_repo.get("version_conflict_policy") == "pinned"
 
         if repo_name in root_module_repos.keys():
             known_contributing_modules = root_repo.get("known_contributing_modules", sets.make())
             if sets.length(known_contributing_modules) == 0:
                 # Warn users if multiple modules contribute to the same maven `name`
-                _warn_if_multiple_contributing_modules(root_repo, repo_name, bazel_dep_to_non_root_artifacts)
+                _warn_if_multiple_contributing_modules(root_repo, repo_name, bazel_dep_to_non_root_artifacts, bazel_dep_to_non_root_boms)
             else:
-                # Filter results so only modules in the known_contributing_modules add artifacts or boms
-                all_non_root_artifact_modules = bazel_dep_to_non_root_artifacts.keys()
-                bazel_dep_to_non_root_artifacts = {
-                    k: bazel_dep_to_non_root_artifacts[k]
-                    for k in sets.to_list(known_contributing_modules)
-                    if k in bazel_dep_to_non_root_artifacts
-                }
-                if rje_verbose_env_var:
-                    for k in all_non_root_artifact_modules:
-                        if k not in bazel_dep_to_non_root_artifacts.keys():
-                            print("\nINFO: The @%s repo is not using deps from %s because it is not in the known_contributing_modules" % (repo_name, k))
-                all_non_root_bom_modules = bazel_dep_to_non_root_boms.keys()
-                bazel_dep_to_non_root_boms = {
-                    k: bazel_dep_to_non_root_boms[k]
-                    for k in sets.to_list(known_contributing_modules)
-                    if k in bazel_dep_to_non_root_boms
-                }
-                if rje_verbose_env_var:
-                    for k in all_non_root_bom_modules:
-                        if k not in bazel_dep_to_non_root_boms.keys():
-                            print("\nINFO: The @%s repo is not using boms from %s because it is not in the known_contributing_modules" % (repo_name, k))
+                # Filter results so only modules in the known_contributing_modules add dependencies.
+                bazel_dep_to_non_root_artifacts = _filter_known_contributing_modules(
+                    repo_name,
+                    "artifacts",
+                    bazel_dep_to_non_root_artifacts,
+                    known_contributing_modules,
+                    rje_verbose_env_var,
+                )
+                bazel_dep_to_non_root_boms = _filter_known_contributing_modules(
+                    repo_name,
+                    "BOMs",
+                    bazel_dep_to_non_root_boms,
+                    known_contributing_modules,
+                    rje_verbose_env_var,
+                )
 
-            merged_repo["artifacts"] = _deduplicate_artifacts_with_root_priority(
+            merged_repo["artifacts"] = _deduplicate_dependencies_with_root_priority(
                 repo_name,
                 root_artifacts,
                 bazel_dep_to_non_root_artifacts,
                 repin_env_var,
                 rje_verbose_env_var,
+                "artifact",
+                root_pinned_policy = root_pinned_policy,
+                non_root_pinned_policy = non_root_pinned_policy,
             )
 
-            merged_repo["boms"] = _deduplicate_artifacts_with_root_priority(
+            merged_repo["boms"] = _deduplicate_dependencies_with_root_priority(
                 repo_name,
                 root_boms,
                 bazel_dep_to_non_root_boms,
                 repin_env_var,
                 rje_verbose_env_var,
+                "BOM",
+                root_pinned_policy = root_pinned_policy,
+                non_root_pinned_policy = non_root_pinned_policy,
             )
         else:
-            merged_repo["artifacts"] = _deduplicate_non_root_artifacts(bazel_dep_to_non_root_artifacts, True)
-            merged_repo["boms"] = _deduplicate_non_root_artifacts(bazel_dep_to_non_root_boms, True)
+            merged_repo["artifacts"] = _deduplicate_non_root_dependencies(
+                bazel_dep_to_non_root_artifacts,
+                "artifact",
+                True,
+                pinned_policy = non_root_pinned_policy,
+            )
+            merged_repo["boms"] = _deduplicate_non_root_dependencies(
+                bazel_dep_to_non_root_boms,
+                "BOM",
+                True,
+                pinned_policy = non_root_pinned_policy,
+            )
 
         # For list attributes, concatenate but avoid duplicates (root items first)
         for list_attr in ["repositories", "excluded_artifacts", "additional_netrc_lines", "additional_coursier_options"]:

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/Artifact.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/Artifact.java
@@ -56,9 +56,11 @@ public class Artifact {
   @Override
   public String toString() {
     if (exclusions.isEmpty()) {
-      return "{" + coordinates + "}";
+      return forceVersion ? "{" + coordinates + ", forceVersion=true}" : "{" + coordinates + "}";
     }
-    return "{" + coordinates + ", exclusions=" + exclusions + "}";
+    return forceVersion
+        ? "{" + coordinates + ", exclusions=" + exclusions + ", forceVersion=true}"
+        : "{" + coordinates + ", exclusions=" + exclusions + "}";
   }
 
   @Override
@@ -70,12 +72,13 @@ public class Artifact {
       return false;
     }
     Artifact that = (Artifact) o;
-    return Objects.equals(this.getCoordinates(), that.getCoordinates())
+    return this.isForceVersion() == that.isForceVersion()
+        && Objects.equals(this.getCoordinates(), that.getCoordinates())
         && Objects.equals(this.getExclusions(), that.getExclusions());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getCoordinates(), getExclusions());
+    return Objects.hash(getCoordinates(), getExclusions(), isForceVersion());
   }
 }

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/ResolutionRequest.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/ResolutionRequest.java
@@ -61,10 +61,15 @@ public class ResolutionRequest {
 
   public ResolutionRequest addBom(String coordinates, String... exclusions) {
     Objects.requireNonNull(coordinates, "BOM coordinates");
-    return addBom(new Coordinates(coordinates), exclusions);
+    return addBom(new Coordinates(coordinates), false, exclusions);
   }
 
   public ResolutionRequest addBom(Coordinates coordinates, String... exclusions) {
+    return addBom(coordinates, false, exclusions);
+  }
+
+  public ResolutionRequest addBom(
+      Coordinates coordinates, boolean forceVersion, String... exclusions) {
     Objects.requireNonNull(coordinates, "BOM coordinates");
 
     Coordinates bom =
@@ -75,7 +80,10 @@ public class ResolutionRequest {
             "",
             coordinates.getVersion());
     Artifact artifact =
-        new Artifact(bom, Stream.of(exclusions).map(Coordinates::new).collect(Collectors.toSet()));
+        new Artifact(
+            bom,
+            Stream.of(exclusions).map(Coordinates::new).collect(Collectors.toSet()),
+            forceVersion);
 
     return addBom(artifact);
   }
@@ -128,7 +136,7 @@ public class ResolutionRequest {
 
     getRepositories().forEach(toReturn::addRepository);
     amended.forEach(toReturn::addArtifact);
-    getBoms().stream().map(Objects::toString).forEach(toReturn::addBom);
+    getBoms().forEach(toReturn::addBom);
     getGlobalExclusions().forEach(toReturn::exclude);
     toReturn.useUnsafeSharedCache = isUseUnsafeSharedCache();
     toReturn.userHome = userHome;

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd/ResolverConfig.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd/ResolverConfig.java
@@ -162,7 +162,8 @@ public class ResolverConfig {
                         .append(":")
                         .append(art.getVersion());
                 request.addBom(
-                    coords.toString(),
+                    new Coordinates(coords.toString()),
+                    art.isForceVersion(),
                     art.getExclusions().stream()
                         .map(c -> c.getGroupId() + ":" + c.getArtifactId())
                         .toArray(String[]::new));

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleBuildScriptGenerator.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleBuildScriptGenerator.java
@@ -36,6 +36,11 @@ public class GradleBuildScriptGenerator {
 
   private static final Handlebars handlebars = new Handlebars();
 
+  private static boolean isForceVersion(GradleDependency dependency) {
+    String version = dependency.getVersion();
+    return version != null && version.endsWith("!!");
+  }
+
   static {
     handlebars.registerHelper(
         "notEmpty",
@@ -125,29 +130,22 @@ public class GradleBuildScriptGenerator {
                 })
             .collect(Collectors.toList()));
 
-    // If multiple versions of a BOM exists, we want to enforce the first one like maven
-    // Unlike maven, gradle seems to choose the highest versions, so this emulates the maven
-    // behavior by picking the first BOM version in the order we see.
-    Map<String, String> enforcedBomVersions = new LinkedHashMap<>();
+    // If multiple versions of a BOM exist, pick one version to keep Gradle from selecting a
+    // different version during conflict resolution. A forced BOM wins over an unforced BOM, and
+    // later forced BOMs match the Maven resolver's last-forced-wins behavior.
+    Map<String, GradleDependency> selectedBoms = new LinkedHashMap<>();
     boms.forEach(
         bom -> {
           String artifactKey = bom.getGroup() + ":" + bom.getArtifact();
-          if (!enforcedBomVersions.containsKey(artifactKey)) {
-            enforcedBomVersions.put(artifactKey, bom.getVersion());
+          GradleDependency selectedBom = selectedBoms.get(artifactKey);
+          if (selectedBom == null || isForceVersion(bom)) {
+            selectedBoms.put(artifactKey, bom);
           }
         });
 
     // Now get the boms filtered to include the "winning" boms if there are multiple versions of a
     // given one
-    List<GradleDependency> actualBoms =
-        boms.stream()
-            .filter(
-                bom -> {
-                  String artifactKey = bom.getGroup() + ":" + bom.getArtifact();
-                  return enforcedBomVersions.containsKey(artifactKey)
-                      && enforcedBomVersions.get(artifactKey).equals(bom.getVersion());
-                })
-            .collect(Collectors.toList());
+    List<GradleDependency> actualBoms = selectedBoms.values().stream().collect(Collectors.toList());
 
     contextMap.put(
         "boms",
@@ -157,7 +155,16 @@ public class GradleBuildScriptGenerator {
                   Map<String, Object> map = new HashMap<>();
                   map.put("group", dep.getGroup());
                   map.put("artifact", dep.getArtifact());
-                  map.put("version", dep.getVersion());
+                  String version = dep.getVersion();
+                  boolean isForceVersion = isForceVersion(dep);
+                  if (isForceVersion) {
+                    version = version.substring(0, version.length() - 2);
+                    map.put("forceVersion", true);
+                    map.put("versionOnly", version);
+                  } else {
+                    map.put("forceVersion", false);
+                  }
+                  map.put("version", version);
                   return map;
                 })
             .collect(Collectors.toList()));
@@ -172,7 +179,7 @@ public class GradleBuildScriptGenerator {
                   map.put("artifact", dep.getArtifact());
 
                   String version = dep.getVersion();
-                  boolean isForceVersion = version != null && version.endsWith("!!");
+                  boolean isForceVersion = isForceVersion(dep);
                   if (isForceVersion) {
                     // Strip the !! suffix, we'll use version { strictly() } in template
                     version = version.substring(0, version.length() - 2);

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/data/build.gradle.hbs
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/data/build.gradle.hbs
@@ -24,7 +24,13 @@ repositories {
 
 dependencies {
 {{~#each boms}}
+{{~#if forceVersion}}
+    implementation(platform("{{group}}:{{artifact}}")) {
+        version { strictly("{{versionOnly}}") }
+    }
+{{~else}}
     implementation platform("{{group}}:{{artifact}}:{{version}}")
+{{~/if}}
 {{~/each}}
 {{~#each dependencies}}
     implementation("{{group}}:{{artifact}}{{version}}{{~#if classifier}}{{classifier}}{{~/if}}{{~#if extension}}{{extension}}{{~/if}}"){{~#if exclusions}}{{~#if forceVersion}} {
@@ -50,6 +56,11 @@ configurations.all {
 {{~/if}}
     resolutionStrategy {
 {{~#each dependencies}}
+{{~#if forceVersion}}
+        force("{{group}}:{{artifact}}:{{versionOnly}}")
+{{~/if}}
+{{~/each}}
+{{~#each boms}}
 {{~#if forceVersion}}
         force("{{group}}:{{artifact}}:{{versionOnly}}")
 {{~/if}}

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/maven/MavenResolver.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/maven/MavenResolver.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -178,7 +179,8 @@ public class MavenResolver implements Resolver {
     List<Dependency> bomsWithGlobalExclusions = addGlobalExclusions(globalExclusions, boms);
     consoleLogListener.setPhase("Resolving " + bomsWithGlobalExclusions.size() + " BOM artifacts");
     List<Dependency> bomDependencies =
-        resolveArtifactsFromBoms(system, session, repositories, bomsWithGlobalExclusions);
+        resolveArtifactsFromBoms(
+            system, session, repositories, bomsWithGlobalExclusions, request.getBoms());
 
     List<Dependency> managedDependencies = createManagedDependencies(bomDependencies, dependencies);
 
@@ -489,24 +491,34 @@ public class MavenResolver implements Resolver {
       RepositorySystem system,
       RepositorySystemSession session,
       List<RemoteRepository> repositories,
-      List<Dependency> boms) {
-    // Use LinkedHashSet to maintain order of how BOMS were declared
-    Set<Dependency> managedDependencies = new LinkedHashSet<>();
+      List<Dependency> boms,
+      List<com.github.bazelbuild.rules_jvm_external.resolver.Artifact> originalBoms) {
+    Map<String, Dependency> managedDependencies = new LinkedHashMap<>();
 
-    for (Dependency bom : boms) {
+    for (int i = 0; i < boms.size(); i++) {
+      Dependency bom = boms.get(i);
+      boolean forceVersion = originalBoms.get(i).isForceVersion();
       ArtifactDescriptorRequest request =
           new ArtifactDescriptorRequest(bom.getArtifact(), repositories, JavaScopes.COMPILE);
       try {
         ArtifactDescriptorResult result = system.readArtifactDescriptor(session, request);
-        // NOTE: BOM dependencies are added in order so dependencies from eariler BOMs will
-        // take precedence over dependencies from later BOMs
-        managedDependencies.addAll(result.getManagedDependencies());
+        result
+            .getManagedDependencies()
+            .forEach(
+                dep -> {
+                  String artifactKey = getArtifactKey(dep.getArtifact());
+                  if (forceVersion) {
+                    managedDependencies.put(artifactKey, dep);
+                  } else {
+                    managedDependencies.putIfAbsent(artifactKey, dep);
+                  }
+                });
       } catch (ArtifactDescriptorException e) {
         throw new RuntimeException(e);
       }
     }
 
-    return ImmutableList.copyOf(managedDependencies);
+    return ImmutableList.copyOf(managedDependencies.values());
   }
 
   private List<Dependency> addGlobalExclusions(

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/BUILD
@@ -1,5 +1,20 @@
 load("@rules_java//java:java_library.bzl", "java_library")
+load("@rules_java//java:java_test.bzl", "java_test")
 load("//:defs.bzl", "artifact")
+
+java_test(
+    name = "ResolutionRequestTest",
+    srcs = ["ResolutionRequestTest.java"],
+    test_class = "com.github.bazelbuild.rules_jvm_external.resolver.ResolutionRequestTest",
+    deps = [
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external",
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver",
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing_coursier",
+        ),
+    ],
+)
 
 java_library(
     name = "resolver",

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/ResolutionRequestTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/ResolutionRequestTest.java
@@ -1,0 +1,54 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.github.bazelbuild.rules_jvm_external.resolver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.github.bazelbuild.rules_jvm_external.Coordinates;
+import java.util.List;
+import java.util.Set;
+import org.junit.Test;
+
+public class ResolutionRequestTest {
+
+  @Test
+  public void artifactEqualityIncludesForceVersion() {
+    Coordinates coordinates = new Coordinates("com.example:dependency:1.0");
+
+    assertNotEquals(new Artifact(coordinates, Set.of()), new Artifact(coordinates, Set.of(), true));
+  }
+
+  @Test
+  public void replaceDependenciesPreservesBomMetadata() {
+    Coordinates bomCoordinates = new Coordinates("com.example", "example-bom", "pom", "", "1.0");
+    Artifact forcedBom =
+        new Artifact(bomCoordinates, Set.of(new Coordinates("com.example:excluded")), true);
+    Artifact replacement = new Artifact(new Coordinates("com.example:replacement:1.0"), Set.of());
+
+    ResolutionRequest replaced =
+        new ResolutionRequest()
+            .addRepository("https://repo.example.com")
+            .addBom(forcedBom)
+            .replaceDependencies(List.of(replacement));
+
+    assertEquals(List.of(forcedBom), replaced.getBoms());
+    assertTrue(replaced.getBoms().get(0).isForceVersion());
+    assertEquals(
+        Set.of(new Coordinates("com.example:excluded")), replaced.getBoms().get(0).getExclusions());
+    assertEquals("pom", replaced.getBoms().get(0).getCoordinates().getExtension());
+  }
+}

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/ResolverTestBase.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/ResolverTestBase.java
@@ -665,6 +665,44 @@ public abstract class ResolverTestBase {
   }
 
   @Test
+  public void shouldPrioritizeForcedVersionWhenDuplicateBomVersionsAreRequested() {
+    Coordinates managedCoords = new Coordinates("com.example:managed");
+
+    Coordinates managed1 = new Coordinates("com.example:managed:1.0.0");
+    Coordinates bom1 = new Coordinates("com.example:example-bom:1.0.0");
+    Dependency dependency1 = new Dependency();
+    dependency1.setGroupId(managedCoords.getGroupId());
+    dependency1.setArtifactId(managedCoords.getArtifactId());
+    dependency1.setVersion(managed1.getVersion());
+    DependencyManagement managedDeps1 = new DependencyManagement();
+    managedDeps1.addDependency(dependency1);
+    Model model1 = createModel(bom1);
+    model1.setPackaging("pom");
+    model1.setDependencyManagement(managedDeps1);
+
+    Coordinates managed2 = new Coordinates("com.example:managed:2.0.0");
+    Coordinates bom2 = new Coordinates("com.example:example-bom:2.0.0");
+    Dependency dependency2 = new Dependency();
+    dependency2.setGroupId(managedCoords.getGroupId());
+    dependency2.setArtifactId(managedCoords.getArtifactId());
+    dependency2.setVersion(managed2.getVersion());
+    DependencyManagement managedDeps2 = new DependencyManagement();
+    managedDeps2.addDependency(dependency2);
+    Model model2 = createModel(bom2);
+    model2.setPackaging("pom");
+    model2.setDependencyManagement(managedDeps2);
+
+    Path repo = MavenRepo.create().add(managed1).add(managed2).add(model1).add(model2).getPath();
+
+    ResolutionRequest request = prepareRequestFor(repo.toUri(), managedCoords);
+    request.addBom(bom1);
+    request.addBom(bom2, true);
+
+    Graph<Coordinates> resolved = resolver.resolve(request).getResolution();
+    assertEquals(Set.of(managed2), resolved.nodes());
+  }
+
+  @Test
   public void shouldConsolidateDifferentClassifierVersionsForADependency() {
     Coordinates nettyCoords = new Coordinates("io.netty:netty-tcnative-boringssl-static");
 

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/cmd/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/cmd/BUILD
@@ -1,0 +1,18 @@
+load("@rules_java//java:java_test.bzl", "java_test")
+load("@rules_jvm_external//:defs.bzl", "artifact")
+
+java_test(
+    name = "ResolverConfigTest",
+    srcs = ["ResolverConfigTest.java"],
+    test_class = "com.github.bazelbuild.rules_jvm_external.resolver.cmd.ResolverConfigTest",
+    deps = [
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external",
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver",
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd",
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/ui",
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing_coursier",
+        ),
+    ],
+)

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/cmd/ResolverConfigTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/cmd/ResolverConfigTest.java
@@ -1,0 +1,56 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.github.bazelbuild.rules_jvm_external.resolver.cmd;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.github.bazelbuild.rules_jvm_external.Coordinates;
+import com.github.bazelbuild.rules_jvm_external.resolver.Artifact;
+import com.github.bazelbuild.rules_jvm_external.resolver.ui.NullListener;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Test;
+
+public class ResolverConfigTest {
+
+  @Test
+  public void argsFilePreservesBomForceVersion() throws Exception {
+    Path argsFile = Files.createTempFile("resolver-config", ".json");
+    Files.writeString(
+        argsFile,
+        "{"
+            + "\"repositories\":[\"https://repo1.maven.org/maven2\"],"
+            + "\"boms\":[{"
+            + "\"group\":\"com.example\","
+            + "\"artifact\":\"example-bom\","
+            + "\"version\":\"1.0\","
+            + "\"force_version\":true"
+            + "}],"
+            + "\"artifacts\":[]"
+            + "}");
+
+    ResolverConfig config =
+        new ResolverConfig(new NullListener(), "--argsfile", argsFile.toString());
+
+    Artifact bom = config.getResolutionRequest().getBoms().get(0);
+    Coordinates coordinates = bom.getCoordinates();
+    assertTrue(bom.isForceVersion());
+    assertEquals("com.example", coordinates.getGroupId());
+    assertEquals("example-bom", coordinates.getArtifactId());
+    assertEquals("pom", coordinates.getExtension());
+    assertEquals("1.0", coordinates.getVersion());
+  }
+}

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/BUILD
@@ -2,6 +2,24 @@ load("@rules_java//java:java_test.bzl", "java_test")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 
 java_test(
+    name = "GradleBuildScriptGeneratorTest",
+    srcs = ["GradleBuildScriptGeneratorTest.java"],
+    data = [
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/data:gradle_build_templates",
+    ],
+    test_class = "com.github.bazelbuild.rules_jvm_external.resolver.gradle.GradleBuildScriptGeneratorTest",
+    deps = [
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle",
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/models",
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing_coursier",
+        ),
+        "@bazel_tools//tools/java/runfiles",
+    ],
+)
+
+java_test(
     name = "UnresolvedDepsTest",
     srcs = ["UnresolvedDepsTest.java"],
     test_class = "com.github.bazelbuild.rules_jvm_external.resolver.gradle.UnresolvedDepsTest",

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleBuildScriptGeneratorTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleBuildScriptGeneratorTest.java
@@ -1,0 +1,112 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.github.bazelbuild.rules_jvm_external.resolver.gradle;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.github.bazelbuild.rules_jvm_external.resolver.gradle.models.GradleDependency;
+import com.github.bazelbuild.rules_jvm_external.resolver.gradle.models.GradleDependencyImpl;
+import com.google.devtools.build.runfiles.AutoBazelRepository;
+import com.google.devtools.build.runfiles.Runfiles;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.Test;
+
+@AutoBazelRepository
+public class GradleBuildScriptGeneratorTest {
+
+  @Test
+  public void forcedBomUsesStrictVersionAndResolutionForce() throws Exception {
+    String script =
+        renderBuildScript(
+            List.of(
+                new GradleDependencyImpl(
+                    "com.example", "example-bom", "1.0!!", List.of(), "", "pom")));
+
+    assertTrue(script.contains("implementation(platform(\"com.example:example-bom\"))"));
+    assertTrue(script.contains("version { strictly(\"1.0\") }"));
+    assertTrue(script.contains("force(\"com.example:example-bom:1.0\")"));
+    assertFalse(script.contains("1.0!!"));
+  }
+
+  @Test
+  public void unforcedBomUsesVersionedPlatformNotation() throws Exception {
+    String script =
+        renderBuildScript(
+            List.of(
+                new GradleDependencyImpl(
+                    "com.example", "example-bom", "1.0", List.of(), "", "pom")));
+
+    assertTrue(script.contains("implementation platform(\"com.example:example-bom:1.0\")"));
+    assertFalse(script.contains("force(\"com.example:example-bom:1.0\")"));
+  }
+
+  @Test
+  public void forcedDuplicateBomWinsOverEarlierUnforcedBom() throws Exception {
+    String script =
+        renderBuildScript(
+            List.of(
+                new GradleDependencyImpl("com.example", "example-bom", "1.0", List.of(), "", "pom"),
+                new GradleDependencyImpl(
+                    "com.example", "example-bom", "2.0!!", List.of(), "", "pom")));
+
+    assertTrue(script.contains("implementation(platform(\"com.example:example-bom\"))"));
+    assertTrue(script.contains("version { strictly(\"2.0\") }"));
+    assertTrue(script.contains("force(\"com.example:example-bom:2.0\")"));
+    assertFalse(script.contains("com.example:example-bom:1.0"));
+  }
+
+  @Test
+  public void laterForcedDuplicateBomWinsOverEarlierForcedBom() throws Exception {
+    String script =
+        renderBuildScript(
+            List.of(
+                new GradleDependencyImpl(
+                    "com.example", "example-bom", "1.0!!", List.of(), "", "pom"),
+                new GradleDependencyImpl(
+                    "com.example", "example-bom", "2.0!!", List.of(), "", "pom")));
+
+    assertTrue(script.contains("implementation(platform(\"com.example:example-bom\"))"));
+    assertTrue(script.contains("version { strictly(\"2.0\") }"));
+    assertTrue(script.contains("force(\"com.example:example-bom:2.0\")"));
+    assertFalse(script.contains("com.example:example-bom:1.0"));
+  }
+
+  private String renderBuildScript(List<GradleDependency> boms) throws Exception {
+    Runfiles runfiles =
+        Runfiles.preload()
+            .withSourceRepository(AutoBazelRepository_GradleBuildScriptGeneratorTest.NAME);
+    Path template =
+        Paths.get(
+            runfiles.rlocation(
+                "rules_jvm_external/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/data/build.gradle.hbs"));
+    Path output = Files.createTempFile("rje-build-script", ".gradle");
+
+    GradleBuildScriptGenerator.generateBuildScript(
+        template,
+        output,
+        List.of(new Repository(URI.create("https://repo1.maven.org/maven2"))),
+        List.of(),
+        boms,
+        List.of(),
+        false);
+
+    return Files.readString(output);
+  }
+}

--- a/tests/integration/root_wins_layer/MODULE.bazel
+++ b/tests/integration/root_wins_layer/MODULE.bazel
@@ -7,10 +7,11 @@ local_path_override(
 )
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
-maven.install(
+maven.artifact(
     name = "root_wins",
-    artifacts = [
-        "io.netty:netty-buffer:4.1.110.Final",
-    ],
+    artifact = "netty-buffer",
+    force_version = True,
+    group = "io.netty",
+    version = "4.1.110.Final",
 )
 use_repo(maven, "root_wins")

--- a/tests/integration/root_wins_layer_two/MODULE.bazel
+++ b/tests/integration/root_wins_layer_two/MODULE.bazel
@@ -1,0 +1,17 @@
+module(name = "root_wins_layer_two")
+
+bazel_dep(name = "rules_jvm_external", version = "0.0")
+local_path_override(
+    module_name = "rules_jvm_external",
+    path = "../../../",
+)
+
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+maven.artifact(
+    name = "root_wins",
+    artifact = "netty-buffer",
+    force_version = True,
+    group = "io.netty",
+    version = "4.1.111.Final",
+)
+use_repo(maven, "root_wins")

--- a/tests/unit/version_catalogs_test.bzl
+++ b/tests/unit/version_catalogs_test.bzl
@@ -303,7 +303,7 @@ def _is_bom_field_impl(ctx):
 
     toml_content = """\
 [libraries]
-guava-bom = { module = "com.google.guava:guava-bom", version = "32.1.0-jre", is_bom = "true" }
+guava-bom = { module = "com.google.guava:guava-bom", version = "32.1.0-jre", is_bom = "true", force_version = "true" }
 guava = { module = "com.google.guava:guava", version = "32.1.0-jre" }
 another-bom = { group = "org.example", name = "example-bom", version = "1.0.0", is_bom = "True" }
 not-a-bom = { module = "org.example:example-lib", version = "1.0.0", is_bom = "false" }
@@ -320,6 +320,7 @@ not-a-bom = { module = "org.example:example-lib", version = "1.0.0", is_bom = "f
     asserts.equals(env, "com.google.guava", boms[0].group)
     asserts.equals(env, "guava-bom", boms[0].artifact)
     asserts.equals(env, "32.1.0-jre", boms[0].version)
+    asserts.equals(env, True, boms[0].force_version)
 
     asserts.equals(env, "org.example", boms[1].group)
     asserts.equals(env, "example-bom", boms[1].artifact)


### PR DESCRIPTION
The resolvers accept BOMs from `MODULE.bazel` and version catalogs, but `amend_artifact(force_version = ...)` and `version_conflict_policy = "pinned"` did not consistently preserve forced BOM versions through resolution. This allowed higher transitive BOM versions, or an earlier duplicate requested BOM, to win silently.

## What
- Let `amend_artifact` match BOM declarations as well as artifact declarations
- Normalize pinned version-conflict policy into `force_version` metadata before repo merging
- Preserve BOM `force_version` through `ResolverConfig`
- Render forced Gradle BOMs with `strictly` plus `resolutionStrategy.force`
- Make forced duplicate requested BOMs win in the shared resolver contract, including `MavenResolver`
- Add tests for BOM force-version plumbing, duplicate forced BOM resolution, and Gradle build script rendering

Generated with Codex
