### PR TITLE
Fix lockfile refs for binary-less and cached artifacts

### DIFF
--- a/private/rules/v3_lock_file.bzl
+++ b/private/rules/v3_lock_file.bzl
@@ -149,12 +149,18 @@ def _compute_lock_file_hash_v3_impl(lock_file_contents, repo_keys):
             type_info["sha"] = sha
             all_infos[dep + suffix] = type_info
 
+    # Mirror the guard in AbstractMain.calculateArtifactHash. A binary-less aggregator can be listed
+    # in `repositories`/`dependencies` under its plain `group:artifact` key while `all_infos` only
+    # holds the classifier-suffixed key of a sibling that owns the shasum, so it has no entry here.
+    # Skip absent entries rather than failing; they contribute no hashable artifact.
     for repo in repo_keys:
         for artifact in lock_file_contents["repositories"][repo]:
-            all_infos[artifact]["repository"] = repo
+            if artifact in all_infos:
+                all_infos[artifact]["repository"] = repo
 
     for dep, dep_info in lock_file_contents["dependencies"].items():
-        all_infos[dep]["dependencies"] = sorted(dep_info)
+        if dep in all_infos:
+            all_infos[dep]["dependencies"] = sorted(dep_info)
 
     return _compute_final_hash(all_infos)
 
@@ -231,9 +237,42 @@ def _from_key(key, spoofed_version):
 
     return to_return
 
+def _artifact_keys(raw_artifacts):
+    # The set of keys `_get_artifacts` will actually generate a target for: one per classifier
+    # shasum of each artifact root. A binary-less aggregator that shares its `group:artifact` root
+    # with a classified sibling produces only the sibling's suffixed key, never its own plain key.
+    keys = {}
+    for (root, data) in raw_artifacts.items():
+        parts = root.split(":")
+        root_unpacked = {
+            "group": parts[0],
+            "artifact": parts[1],
+            "version": data["version"],
+        }
+        if len(parts) > 2:
+            root_unpacked["packaging"] = parts[2]
+        else:
+            root_unpacked["packaging"] = "jar"
+
+        for classifier in data.get("shasums", {}).keys():
+            root_unpacked["classifier"] = classifier
+            keys[to_key(root_unpacked)] = True
+    return keys
+
+def _filter_dependency_targets(raw_dependencies, valid_keys):
+    # Drop dependency edges that point at a coordinate with no generated target (e.g. the plain key
+    # of a binary-less aggregator), which would otherwise produce a dangling target reference.
+    filtered_dependencies = {}
+    for (dep, dependencies) in raw_dependencies.items():
+        filtered_dependencies[dep] = [target for target in dependencies if target in valid_keys]
+    return filtered_dependencies
+
 def _get_artifacts(lock_file_contents):
     raw_artifacts = lock_file_contents.get("artifacts", {})
-    dependencies = lock_file_contents.get("dependencies", {})
+    dependencies = _filter_dependency_targets(
+        lock_file_contents.get("dependencies", {}),
+        _artifact_keys(raw_artifacts),
+    )
     repositories = lock_file_contents.get("repositories", {})
     files = lock_file_contents.get("files", {})
     skipped = lock_file_contents.get("skipped", [])

--- a/private/rules/v3_lock_file.bzl
+++ b/private/rules/v3_lock_file.bzl
@@ -149,18 +149,12 @@ def _compute_lock_file_hash_v3_impl(lock_file_contents, repo_keys):
             type_info["sha"] = sha
             all_infos[dep + suffix] = type_info
 
-    # Mirror the guard in AbstractMain.calculateArtifactHash. A binary-less aggregator can be listed
-    # in `repositories`/`dependencies` under its plain `group:artifact` key while `all_infos` only
-    # holds the classifier-suffixed key of a sibling that owns the shasum, so it has no entry here.
-    # Skip absent entries rather than failing; they contribute no hashable artifact.
     for repo in repo_keys:
         for artifact in lock_file_contents["repositories"][repo]:
-            if artifact in all_infos:
-                all_infos[artifact]["repository"] = repo
+            all_infos[artifact]["repository"] = repo
 
     for dep, dep_info in lock_file_contents["dependencies"].items():
-        if dep in all_infos:
-            all_infos[dep]["dependencies"] = sorted(dep_info)
+        all_infos[dep]["dependencies"] = sorted(dep_info)
 
     return _compute_final_hash(all_infos)
 
@@ -237,42 +231,9 @@ def _from_key(key, spoofed_version):
 
     return to_return
 
-def _artifact_keys(raw_artifacts):
-    # The set of keys `_get_artifacts` will actually generate a target for: one per classifier
-    # shasum of each artifact root. A binary-less aggregator that shares its `group:artifact` root
-    # with a classified sibling produces only the sibling's suffixed key, never its own plain key.
-    keys = {}
-    for (root, data) in raw_artifacts.items():
-        parts = root.split(":")
-        root_unpacked = {
-            "group": parts[0],
-            "artifact": parts[1],
-            "version": data["version"],
-        }
-        if len(parts) > 2:
-            root_unpacked["packaging"] = parts[2]
-        else:
-            root_unpacked["packaging"] = "jar"
-
-        for classifier in data.get("shasums", {}).keys():
-            root_unpacked["classifier"] = classifier
-            keys[to_key(root_unpacked)] = True
-    return keys
-
-def _filter_dependency_targets(raw_dependencies, valid_keys):
-    # Drop dependency edges that point at a coordinate with no generated target (e.g. the plain key
-    # of a binary-less aggregator), which would otherwise produce a dangling target reference.
-    filtered_dependencies = {}
-    for (dep, dependencies) in raw_dependencies.items():
-        filtered_dependencies[dep] = [target for target in dependencies if target in valid_keys]
-    return filtered_dependencies
-
 def _get_artifacts(lock_file_contents):
     raw_artifacts = lock_file_contents.get("artifacts", {})
-    dependencies = _filter_dependency_targets(
-        lock_file_contents.get("dependencies", {}),
-        _artifact_keys(raw_artifacts),
-    )
+    dependencies = lock_file_contents.get("dependencies", {})
     repositories = lock_file_contents.get("repositories", {})
     files = lock_file_contents.get("files", {})
     skipped = lock_file_contents.get("skipped", [])

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd/AbstractMain.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd/AbstractMain.java
@@ -346,19 +346,31 @@ public abstract class AbstractMain {
       }
     }
 
+    // A binary-less aggregator (e.g. a Gradle module-metadata umbrella) contributes no hashable
+    // artifact, so it has no entry in `allInfos`. This also happens when such a coordinate shares
+    // its `group:artifact` key with a classified sibling that owns the only shasum: no `jar`
+    // placeholder is added, so only the classified key is reconstructed above. Such a coordinate
+    // can still be listed in the `repositories` and `dependencies` sections, so skip absent entries
+    // rather than dereferencing null.
     Map<String, Iterable<String>> repositories =
         sortMapRecursively((Map<?, ?>) rendered.get("repositories"));
     for (Map.Entry<String, Iterable<String>> repo : repositories.entrySet()) {
       Iterable<String> repoArtifacts = repo.getValue();
       for (String art : repoArtifacts) {
-        allInfos.get(art).put("repository", repo.getKey());
+        Map<String, Object> info = allInfos.get(art);
+        if (info != null) {
+          info.put("repository", repo.getKey());
+        }
       }
     }
 
     Map<String, Set<String>> dependencies =
         sortMapRecursively((Map<?, ?>) rendered.get("dependencies"));
     for (Map.Entry<String, Set<String>> dep : dependencies.entrySet()) {
-      allInfos.get(dep.getKey()).put("dependencies", dep.getValue());
+      Map<String, Object> info = allInfos.get(dep.getKey());
+      if (info != null) {
+        info.put("dependencies", dep.getValue());
+      }
     }
 
     Map<String, Integer> finalHash = new TreeMap<>();

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd/AbstractMain.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/cmd/AbstractMain.java
@@ -346,31 +346,19 @@ public abstract class AbstractMain {
       }
     }
 
-    // A binary-less aggregator (e.g. a Gradle module-metadata umbrella) contributes no hashable
-    // artifact, so it has no entry in `allInfos`. This also happens when such a coordinate shares
-    // its `group:artifact` key with a classified sibling that owns the only shasum: no `jar`
-    // placeholder is added, so only the classified key is reconstructed above. Such a coordinate
-    // can still be listed in the `repositories` and `dependencies` sections, so skip absent entries
-    // rather than dereferencing null.
     Map<String, Iterable<String>> repositories =
         sortMapRecursively((Map<?, ?>) rendered.get("repositories"));
     for (Map.Entry<String, Iterable<String>> repo : repositories.entrySet()) {
       Iterable<String> repoArtifacts = repo.getValue();
       for (String art : repoArtifacts) {
-        Map<String, Object> info = allInfos.get(art);
-        if (info != null) {
-          info.put("repository", repo.getKey());
-        }
+        allInfos.get(art).put("repository", repo.getKey());
       }
     }
 
     Map<String, Set<String>> dependencies =
         sortMapRecursively((Map<?, ?>) rendered.get("dependencies"));
     for (Map.Entry<String, Set<String>> dep : dependencies.entrySet()) {
-      Map<String, Object> info = allInfos.get(dep.getKey());
-      if (info != null) {
-        info.put("dependencies", dep.getValue());
-      }
+      allInfos.get(dep.getKey()).put("dependencies", dep.getValue());
     }
 
     Map<String, Integer> finalHash = new TreeMap<>();

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolver.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolver.java
@@ -207,7 +207,7 @@ public class GradleResolver implements Resolver {
         artifactsByNode.computeIfAbsent(coordinates, k -> new ArrayList<>()).add(artifact);
 
         File artifactFile = artifact.getFile();
-        if (artifactFile != null && artifactFile.exists()) {
+        if (artifactFileMatchesCoordinates(coordinates, artifactFile)) {
           paths.put(coordinates, artifactFile.toPath());
         }
 
@@ -294,27 +294,13 @@ public class GradleResolver implements Resolver {
       }
 
       File bestFile = null;
-      // Prefer jar/aar with name matching artifactId-version to avoid picking wrong version
+      // Prefer the artifact file matching the resolved coordinates to avoid picking wrong versions
+      // or metadata files such as POMs.
       for (GradleResolvedArtifact artifact : entry.getValue()) {
         File file = artifact.getFile();
-        if (file == null || !file.exists()) {
-          continue;
-        }
-        String name = file.getName();
-        boolean isJarOrAar = name.endsWith(".jar") || name.endsWith(".aar");
-        if (isJarOrAar && name.contains(coords.getArtifactId() + "-" + coords.getVersion())) {
+        if (artifactFileMatchesCoordinates(coords, file)) {
           bestFile = file;
           break;
-        }
-      }
-      // Fallback: any existing file (including pom)
-      if (bestFile == null) {
-        for (GradleResolvedArtifact artifact : entry.getValue()) {
-          File file = artifact.getFile();
-          if (file != null && file.exists()) {
-            bestFile = file;
-            break;
-          }
         }
       }
       if (bestFile != null) {
@@ -335,6 +321,15 @@ public class GradleResolver implements Resolver {
 
   private String makeDepKey(String group, String artifact, String version) {
     return group + ":" + artifact + ":" + version;
+  }
+
+  private boolean artifactFileMatchesCoordinates(Coordinates coordinates, File file) {
+    if (file == null || !file.exists()) {
+      return false;
+    }
+
+    Path expectedFileName = Paths.get(coordinates.toRepoPath()).getFileName();
+    return expectedFileName != null && expectedFileName.toString().equals(file.getName());
   }
 
   private void addDependency(

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/lockfile/V3LockFile.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/lockfile/V3LockFile.java
@@ -258,9 +258,13 @@ public class V3LockFile {
           }
         });
 
+    Map<String, Map<String, Object>> finalizedArtifacts =
+        ensureArtifactsAllHaveAtLeastOneShaSum(artifacts);
+    Set<String> artifactKeys = artifactKeys(finalizedArtifacts);
+
     Map<String, Object> lock = new LinkedHashMap<>();
-    lock.put("artifacts", ensureArtifactsAllHaveAtLeastOneShaSum(artifacts));
-    lock.put("dependencies", removeEmptyItems(deps));
+    lock.put("artifacts", finalizedArtifacts);
+    lock.put("dependencies", removeEmptyItems(filterDependencyKeys(deps, artifactKeys)));
     if (renderPackages) {
       lock.put("packages", removeEmptyItems(packages));
     }
@@ -270,7 +274,7 @@ public class V3LockFile {
     }
     // repos is a LinkedHashSet which is iterated in insertion order.
     // Meaning the order from the Starlark repositories array will be preserved.
-    lock.put("repositories", repos);
+    lock.put("repositories", filterRepositoryKeys(repos, artifactKeys));
 
     lock.put("skipped", skipped);
     if (conflicts != null && !conflicts.isEmpty()) {
@@ -287,6 +291,55 @@ public class V3LockFile {
     lock.put("version", "3");
 
     return lock;
+  }
+
+  private Set<String> artifactKeys(Map<String, Map<String, Object>> artifacts) {
+    Set<String> keys = new TreeSet<>();
+    for (Map.Entry<String, Map<String, Object>> entry : artifacts.entrySet()) {
+      String root = entry.getKey();
+      @SuppressWarnings("unchecked")
+      Map<String, Object> shasums = (Map<String, Object>) entry.getValue().get("shasums");
+      if (shasums == null) {
+        continue;
+      }
+
+      boolean isJarType = root.chars().filter(ch -> ch == ':').count() == 1;
+      for (String type : shasums.keySet()) {
+        String suffix = "jar".equals(type) ? "" : (isJarType ? ":jar" : "") + ":" + type;
+        keys.add(root + suffix);
+      }
+    }
+    return keys;
+  }
+
+  private Map<String, Set<String>> filterRepositoryKeys(
+      Map<String, Set<String>> repos, Set<String> artifactKeys) {
+    Map<String, Set<String>> filtered = new LinkedHashMap<>();
+    repos.forEach(
+        (repo, artifacts) ->
+            filtered.put(
+                repo,
+                artifacts.stream()
+                    .filter(artifactKeys::contains)
+                    .collect(Collectors.toCollection(TreeSet::new))));
+    return filtered;
+  }
+
+  private Map<String, Set<String>> filterDependencyKeys(
+      Map<String, Set<String>> deps, Set<String> artifactKeys) {
+    Map<String, Set<String>> filtered = new TreeMap<>();
+    deps.forEach(
+        (dep, dependencies) -> {
+          if (!artifactKeys.contains(dep)) {
+            return;
+          }
+          filtered.put(
+              dep,
+              dependencies.stream()
+                  .filter(artifactKeys::contains)
+                  .collect(Collectors.toCollection(TreeSet::new)));
+        });
+    return filtered;
   }
 
   private Map<String, Map<String, Object>> ensureArtifactsAllHaveAtLeastOneShaSum(

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/remote/Downloader.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/remote/Downloader.java
@@ -125,7 +125,7 @@ public class Downloader {
     Path pathInRepo = null;
     Path knownPath = knownPaths.get(coordsToUse);
 
-    if (knownPath != null && Files.exists(knownPath)) {
+    if (knownPath != null && knownPathMatchesRequest(knownPath, path)) {
       pathInRepo = knownPath;
     } else {
       // Check the local cache for the path first
@@ -177,6 +177,13 @@ public class Downloader {
     String sha256 = calculateSha256(pathInRepo);
 
     return new DownloadResult(coordsToUse, Set.copyOf(repos), pathInRepo, sha256);
+  }
+
+  private boolean knownPathMatchesRequest(Path knownPath, String path) {
+    Path requestedFileName = Paths.get(path).getFileName();
+    return requestedFileName != null
+        && requestedFileName.equals(knownPath.getFileName())
+        && Files.exists(knownPath);
   }
 
   private URI buildUri(URI baseUri, String pathInRepo) {

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolverTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolverTest.java
@@ -87,6 +87,40 @@ public class GradleResolverTest extends ResolverTestBase {
   }
 
   @Test
+  public void doesNotUsePomAsArtifactPathForAvailableAtModule()
+      throws IOException, XMLStreamException {
+    Coordinates baseCoordinates = new Coordinates("com.example:sample:1.0");
+    Coordinates jvmCoordinates = new Coordinates("com.example:sample-jvm:1.0");
+    MavenRepo mavenRepo = MavenRepo.create();
+    GradleModuleMetadataHelper moduleMetadataHelper = new GradleModuleMetadataHelper(mavenRepo);
+
+    Runfiles runfiles =
+        Runfiles.preload().withSourceRepository(AutoBazelRepository_GradleResolverTest.NAME);
+    Path baseMetadataPath =
+        Paths.get(
+            runfiles.rlocation(
+                "rules_jvm_external/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/fixtures/simpleJvmVariant/sample-1.0.module"));
+    String baseMetadata = Files.readString(baseMetadataPath);
+    moduleMetadataHelper.addToMavenRepo(baseCoordinates.setExtension("pom"), baseMetadata);
+
+    Path jvmMetadataPath =
+        Paths.get(
+            runfiles.rlocation(
+                "rules_jvm_external/tests/com/github/bazelbuild/rules_jvm_external/resolver/gradle/fixtures/simpleJvmVariant/sample-jvm-1.0.module"));
+    String jvmMetadata = Files.readString(jvmMetadataPath);
+    moduleMetadataHelper.addToMavenRepo(jvmCoordinates, jvmMetadata);
+
+    ResolutionResult result =
+        resolver.resolve(prepareRequestFor(mavenRepo.getPath().toUri(), baseCoordinates));
+
+    assertEquals(Set.of(baseCoordinates, jvmCoordinates), result.getResolution().nodes());
+    assertTrue(result.getArtifacts().get(baseCoordinates).getPath().isEmpty());
+    assertEquals(
+        "sample-jvm-1.0.jar",
+        result.getArtifacts().get(jvmCoordinates).getPath().get().getFileName().toString());
+  }
+
+  @Test
   public void resolvesJvmButNotAndroidVariant() throws IOException, XMLStreamException {
     // This test validates a scenario similar to
     // https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/5.1.0/okhttp-5.1.0.module

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/lockfile/V3LockFileTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/lockfile/V3LockFileTest.java
@@ -68,29 +68,78 @@ public class V3LockFileTest {
   }
 
   @Test
-  public void calculateArtifactHashToleratesAggregatorSharingShortKeyWithClassifiedSibling() {
-    // Regression test for a real-world crash. A binary-less aggregator (a Gradle module-metadata
-    // umbrella) shares its `group:artifact` short key with a classified sibling. The sibling owns
-    // the only shasum, so `ensureArtifactsAllHaveAtLeastOneShaSum` adds no `jar` placeholder and no
-    // entry is reconstructed for the umbrella in the hash's intermediate map. The umbrella still
-    // appears in the `repositories` and `dependencies` sections, so hashing must not deref null.
-    DependencyInfo umbrella =
+  public void shouldKeepStandaloneAggregatingJarReferences() {
+    Coordinates depCoordinates = new Coordinates("com.example:dep:1.0.0");
+    DependencyInfo aggregator =
         new DependencyInfo(
-            new Coordinates("com.example:umbrella:1.0.0"),
+            new Coordinates("com.example:aggregator:1.0.0"),
             repos,
             Optional.empty(),
             Optional.empty(),
-            Set.of(new Coordinates("com.example:dep:1.0.0")),
+            Set.of(depCoordinates),
+            Set.of(),
+            Set.of(),
+            new TreeMap<>());
+    DependencyInfo dep =
+        new DependencyInfo(
+            depCoordinates,
+            repos,
+            Optional.of(Paths.get("dep-1.0.0.jar")),
+            Optional.of("77e7c2db478e09882e42a74fb2bc821646cbd4e91c20c616fbd5a8c7b7f350b0"),
+            Set.of(),
+            Set.of(),
+            Set.of(),
+            new TreeMap<>());
+
+    Map<String, Object> rendered =
+        new V3LockFile(repos, Set.of(aggregator, dep), Set.of(), true).render();
+
+    Map<?, ?> artifacts = (Map<?, ?>) rendered.get("artifacts");
+    Map<?, ?> data = (Map<?, ?>) artifacts.get("com.example:aggregator");
+    Map<?, ?> shasums = (Map<?, ?>) data.get("shasums");
+
+    HashMap<Object, Object> expected = new HashMap<>();
+    expected.put("jar", null);
+    assertEquals(expected, shasums);
+
+    Map<?, ?> dependencies = (Map<?, ?>) rendered.get("dependencies");
+    assertEquals(Set.of("com.example:dep"), dependencies.get("com.example:aggregator"));
+
+    Map<?, ?> repositories = (Map<?, ?>) rendered.get("repositories");
+    assertTrue(
+        ((Set<?>) repositories.get(defaultRepo.toString())).contains("com.example:aggregator"));
+
+    assertLockReferencesOnlyArtifactKeys(rendered);
+    assertTrue(AbstractMain.calculateArtifactHash(rendered).containsKey("com.example:aggregator"));
+  }
+
+  @Test
+  public void shouldRemoveNonEmittedAggregatorKeysWhenClassifiedSiblingOwnsShasum() {
+    // A binary-less aggregator can share its `group:artifact` short key with a classified sibling.
+    // The sibling owns the only shasum, so the plain key is not emitted as an artifact target.
+    Coordinates umbrellaCoordinates = new Coordinates("com.example:umbrella:1.0.0");
+    Coordinates unshadedCoordinates =
+        new Coordinates("com.example", "umbrella", "jar", "unshaded", "1.0.0");
+    Coordinates depCoordinates = new Coordinates("com.example:dep:1.0.0");
+    Coordinates rootCoordinates = new Coordinates("com.example:root:1.0.0");
+
+    DependencyInfo umbrella =
+        new DependencyInfo(
+            umbrellaCoordinates,
+            repos,
+            Optional.empty(),
+            Optional.empty(),
+            Set.of(depCoordinates),
             Set.of(),
             Set.of(),
             new TreeMap<>());
     DependencyInfo unshadedSibling =
         new DependencyInfo(
-            new Coordinates("com.example", "umbrella", "jar", "unshaded", "1.0.0"),
+            unshadedCoordinates,
             repos,
             Optional.of(Paths.get("umbrella-1.0.0-unshaded.jar")),
             Optional.of("52b70baa4650255f6c06b4401f9f5ab74038c4d0f50357077033c6bfd504f2aa"),
-            Set.of(),
+            Set.of(depCoordinates),
             Set.of(),
             Set.of(),
             new TreeMap<>());
@@ -104,17 +153,86 @@ public class V3LockFileTest {
             Set.of(),
             Set.of(),
             new TreeMap<>());
+    DependencyInfo root =
+        new DependencyInfo(
+            rootCoordinates,
+            repos,
+            Optional.of(Paths.get("root-1.0.0.jar")),
+            Optional.of("55eb963f66c63e0513f8f0898f24a5d9933b7634b1ac50811f305ec19c926bb8"),
+            Set.of(umbrellaCoordinates, unshadedCoordinates, depCoordinates),
+            Set.of(),
+            Set.of(),
+            new TreeMap<>());
 
     Map<String, Object> rendered =
-        new V3LockFile(repos, Set.of(umbrella, unshadedSibling, dep), Set.of(), true).render();
+        new V3LockFile(repos, Set.of(umbrella, unshadedSibling, dep, root), Set.of(), true)
+            .render();
 
-    // Before the fix this threw NullPointerException at the repositories/dependencies loops.
+    Map<?, ?> artifacts = (Map<?, ?>) rendered.get("artifacts");
+    Map<?, ?> umbrellaData = (Map<?, ?>) artifacts.get("com.example:umbrella");
+    Map<?, ?> shasums = (Map<?, ?>) umbrellaData.get("shasums");
+    assertEquals(Set.of("unshaded"), shasums.keySet());
+
+    Map<?, ?> repositories = (Map<?, ?>) rendered.get("repositories");
+    Set<?> repoArtifacts = (Set<?>) repositories.get(defaultRepo.toString());
+    assertFalse(repoArtifacts.contains("com.example:umbrella"));
+    assertTrue(repoArtifacts.contains("com.example:umbrella:jar:unshaded"));
+
+    Map<?, ?> dependencies = (Map<?, ?>) rendered.get("dependencies");
+    assertFalse(dependencies.containsKey("com.example:umbrella"));
+    Set<?> rootDependencies = (Set<?>) dependencies.get("com.example:root");
+    assertFalse(rootDependencies.contains("com.example:umbrella"));
+    assertTrue(rootDependencies.contains("com.example:umbrella:jar:unshaded"));
+
+    assertLockReferencesOnlyArtifactKeys(rendered);
     Map<String, Integer> hash = AbstractMain.calculateArtifactHash(rendered);
 
-    // The sha-bearing artifacts are hashed; the binary-less umbrella contributes no hashable entry.
     assertTrue(hash.containsKey("com.example:umbrella:jar:unshaded"));
     assertTrue(hash.containsKey("com.example:dep"));
+    assertTrue(hash.containsKey("com.example:root"));
     assertFalse(hash.containsKey("com.example:umbrella"));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void assertLockReferencesOnlyArtifactKeys(Map<String, Object> rendered) {
+    Set<String> artifactKeys = artifactKeys(rendered);
+
+    Map<String, Set<String>> repositories = (Map<String, Set<String>>) rendered.get("repositories");
+    for (Map.Entry<String, Set<String>> repo : repositories.entrySet()) {
+      for (String artifact : repo.getValue()) {
+        assertTrue(
+            "Repository references non-emitted artifact: " + artifact,
+            artifactKeys.contains(artifact));
+      }
+    }
+
+    Map<String, Set<String>> dependencies = (Map<String, Set<String>>) rendered.get("dependencies");
+    for (Map.Entry<String, Set<String>> dep : dependencies.entrySet()) {
+      assertTrue(
+          "Dependency key is not an emitted artifact: " + dep.getKey(),
+          artifactKeys.contains(dep.getKey()));
+      for (String target : dep.getValue()) {
+        assertTrue(
+            "Dependency references non-emitted artifact: " + target, artifactKeys.contains(target));
+      }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Set<String> artifactKeys(Map<String, Object> rendered) {
+    Map<String, Map<String, Object>> artifacts =
+        (Map<String, Map<String, Object>>) rendered.get("artifacts");
+    Set<String> keys = new TreeSet<>();
+    for (Map.Entry<String, Map<String, Object>> entry : artifacts.entrySet()) {
+      String root = entry.getKey();
+      Map<String, Object> shasums = (Map<String, Object>) entry.getValue().get("shasums");
+      boolean isJarType = root.chars().filter(ch -> ch == ':').count() == 1;
+      for (String type : shasums.keySet()) {
+        String suffix = "jar".equals(type) ? "" : (isJarType ? ":jar" : "") + ":" + type;
+        keys.add(root + suffix);
+      }
+    }
+    return keys;
   }
 
   @Test

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/lockfile/V3LockFileTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/lockfile/V3LockFileTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import com.github.bazelbuild.rules_jvm_external.Coordinates;
 import com.github.bazelbuild.rules_jvm_external.resolver.Conflict;
@@ -27,6 +28,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -63,6 +65,56 @@ public class V3LockFileTest {
     HashMap<Object, Object> expected = new HashMap<>();
     expected.put("jar", null);
     assertEquals(expected, shasums);
+  }
+
+  @Test
+  public void calculateArtifactHashToleratesAggregatorSharingShortKeyWithClassifiedSibling() {
+    // Regression test for a real-world crash. A binary-less aggregator (a Gradle module-metadata
+    // umbrella) shares its `group:artifact` short key with a classified sibling. The sibling owns
+    // the only shasum, so `ensureArtifactsAllHaveAtLeastOneShaSum` adds no `jar` placeholder and no
+    // entry is reconstructed for the umbrella in the hash's intermediate map. The umbrella still
+    // appears in the `repositories` and `dependencies` sections, so hashing must not deref null.
+    DependencyInfo umbrella =
+        new DependencyInfo(
+            new Coordinates("com.example:umbrella:1.0.0"),
+            repos,
+            Optional.empty(),
+            Optional.empty(),
+            Set.of(new Coordinates("com.example:dep:1.0.0")),
+            Set.of(),
+            Set.of(),
+            new TreeMap<>());
+    DependencyInfo unshadedSibling =
+        new DependencyInfo(
+            new Coordinates("com.example", "umbrella", "jar", "unshaded", "1.0.0"),
+            repos,
+            Optional.of(Paths.get("umbrella-1.0.0-unshaded.jar")),
+            Optional.of("52b70baa4650255f6c06b4401f9f5ab74038c4d0f50357077033c6bfd504f2aa"),
+            Set.of(),
+            Set.of(),
+            Set.of(),
+            new TreeMap<>());
+    DependencyInfo dep =
+        new DependencyInfo(
+            new Coordinates("com.example:dep:1.0.0"),
+            repos,
+            Optional.of(Paths.get("dep-1.0.0.jar")),
+            Optional.of("77e7c2db478e09882e42a74fb2bc821646cbd4e91c20c616fbd5a8c7b7f350b0"),
+            Set.of(),
+            Set.of(),
+            Set.of(),
+            new TreeMap<>());
+
+    Map<String, Object> rendered =
+        new V3LockFile(repos, Set.of(umbrella, unshadedSibling, dep), Set.of(), true).render();
+
+    // Before the fix this threw NullPointerException at the repositories/dependencies loops.
+    Map<String, Integer> hash = AbstractMain.calculateArtifactHash(rendered);
+
+    // The sha-bearing artifacts are hashed; the binary-less umbrella contributes no hashable entry.
+    assertTrue(hash.containsKey("com.example:umbrella:jar:unshaded"));
+    assertTrue(hash.containsKey("com.example:dep"));
+    assertFalse(hash.containsKey("com.example:umbrella"));
   }
 
   @Test

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/maven/DownloaderTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/maven/DownloaderTest.java
@@ -14,6 +14,7 @@
 
 package com.github.bazelbuild.rules_jvm_external.resolver.maven;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.github.bazelbuild.rules_jvm_external.Coordinates;
@@ -25,6 +26,8 @@ import com.github.bazelbuild.rules_jvm_external.resolver.ui.NullListener;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 import java.util.Set;
 import org.junit.Test;
@@ -68,5 +71,37 @@ public class DownloaderTest {
             .download(coords);
 
     assertTrue(downloadResult.getPath().isEmpty());
+  }
+
+  @Test
+  public void downloaderIgnoresKnownPathWithDifferentFilename() throws Exception {
+    Coordinates coords = new Coordinates("com.example:cached-path:1.0");
+    Path repo = MavenRepo.create().add(coords).getPath();
+    Path expectedJar = repo.resolve(coords.toRepoPath());
+    Path pomPath =
+        expectedJar.resolveSibling(coords.getArtifactId() + "-" + coords.getVersion() + ".pom");
+    Path localRepo = Files.createTempDirectory("local");
+
+    DownloadResult downloadResult =
+        new Downloader(
+                Netrc.fromUserHome(),
+                localRepo,
+                Set.of(repo.toUri()),
+                new NullListener(),
+                false,
+                Map.of(coords, pomPath))
+            .download(coords);
+
+    assertEquals(expectedJar, downloadResult.getPath().get());
+    assertEquals(sha256(expectedJar), downloadResult.getSha256().get());
+  }
+
+  private String sha256(Path path) throws IOException, NoSuchAlgorithmException {
+    byte[] digest = MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(path));
+    StringBuilder hex = new StringBuilder();
+    for (byte b : digest) {
+      hex.append(String.format("%02x", b));
+    }
+    return hex.toString();
   }
 }

--- a/tests/unit/BUILD
+++ b/tests/unit/BUILD
@@ -7,6 +7,7 @@ load(":java_utilities_test.bzl", "java_utilities_test_suite")
 load(":maven_version_test.bzl", "maven_version_test_suite")
 load(":proxy_test.bzl", "proxy_test_suite")
 load(":specs_test.bzl", "artifact_specs_test_suite")
+load(":v3_lock_file_test.bzl", "v3_lock_file_test_suite")
 load(":version_catalogs_test.bzl", "version_catalogs_test_suite")
 
 amend_artifact_test_suite()
@@ -26,5 +27,7 @@ java_utilities_test_suite()
 maven_version_test_suite()
 
 proxy_test_suite()
+
+v3_lock_file_test_suite()
 
 version_catalogs_test_suite()

--- a/tests/unit/v3_lock_file_test.bzl
+++ b/tests/unit/v3_lock_file_test.bzl
@@ -1,46 +1,6 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//private/rules:v3_lock_file.bzl", "v3_lock_file")
 
-def _get_artifacts_ignores_dependency_targets_without_artifacts_test_impl(ctx):
-    env = unittest.begin(ctx)
-
-    artifacts = v3_lock_file.get_artifacts({
-        "artifacts": {
-            "com.example:dep": {
-                "shasums": {
-                    "jar": "def",
-                },
-                "version": "1.0",
-            },
-            "com.example:root": {
-                "shasums": {
-                    "jar": "abc",
-                },
-                "version": "1.0",
-            },
-        },
-        "dependencies": {
-            "com.example:root": [
-                "com.example:dep",
-                "com.example:missing-native",
-            ],
-        },
-        "repositories": {},
-        "services": {},
-        "version": "3",
-    })
-
-    # `com.example:missing-native` has no artifact entry, so the dependency edge is dropped rather
-    # than emitting a dangling target reference.
-    root = [artifact for artifact in artifacts if artifact["coordinates"] == "com.example:root:1.0"][0]
-    asserts.equals(env, ["com.example:dep:spoofed-version"], root["deps"])
-
-    return unittest.end(env)
-
-get_artifacts_ignores_dependency_targets_without_artifacts_test = unittest.make(
-    _get_artifacts_ignores_dependency_targets_without_artifacts_test_impl,
-)
-
 def _get_artifacts_keeps_classifier_dependency_targets_test_impl(ctx):
     env = unittest.begin(ctx)
 
@@ -62,7 +22,6 @@ def _get_artifacts_keeps_classifier_dependency_targets_test_impl(ctx):
         "dependencies": {
             "com.example:root": [
                 "com.example:dep:jar:test-fixtures",
-                "com.example:missing-native",
             ],
         },
         "repositories": {},
@@ -70,7 +29,6 @@ def _get_artifacts_keeps_classifier_dependency_targets_test_impl(ctx):
         "version": "3",
     })
 
-    # A classifier dependency target that does have a matching shasum is preserved.
     root = [artifact for artifact in artifacts if artifact["coordinates"] == "com.example:root:1.0"][0]
     asserts.equals(env, ["com.example:dep:spoofed-version:test-fixtures@jar"], root["deps"])
 
@@ -80,13 +38,9 @@ get_artifacts_keeps_classifier_dependency_targets_test = unittest.make(
     _get_artifacts_keeps_classifier_dependency_targets_test_impl,
 )
 
-def _compute_lock_file_hash_tolerates_aggregator_sharing_key_with_sibling_test_impl(ctx):
+def _compute_lock_file_hash_accepts_cleaned_aggregator_collision_test_impl(ctx):
     env = unittest.begin(ctx)
 
-    # A binary-less aggregator (`com.example:umbrella`) shares its `group:artifact` key with a
-    # classified sibling (`com.example:umbrella:jar:unshaded`) that owns the only shasum. The plain
-    # key still appears in `repositories` and `dependencies` but is never reconstructed into the
-    # hash's intermediate map, so computing the hash must not fail on the missing key.
     hashes = v3_lock_file.compute_lock_file_hash({
         "artifacts": {
             "com.example:dep": {
@@ -103,13 +57,11 @@ def _compute_lock_file_hash_tolerates_aggregator_sharing_key_with_sibling_test_i
             },
         },
         "dependencies": {
-            "com.example:umbrella": ["com.example:dep"],
             "com.example:umbrella:jar:unshaded": ["com.example:dep"],
         },
         "repositories": {
             "https://example.com/repo/": [
                 "com.example:dep",
-                "com.example:umbrella",
                 "com.example:umbrella:jar:unshaded",
             ],
         },
@@ -122,14 +74,13 @@ def _compute_lock_file_hash_tolerates_aggregator_sharing_key_with_sibling_test_i
 
     return unittest.end(env)
 
-compute_lock_file_hash_tolerates_aggregator_sharing_key_with_sibling_test = unittest.make(
-    _compute_lock_file_hash_tolerates_aggregator_sharing_key_with_sibling_test_impl,
+compute_lock_file_hash_accepts_cleaned_aggregator_collision_test = unittest.make(
+    _compute_lock_file_hash_accepts_cleaned_aggregator_collision_test_impl,
 )
 
 def v3_lock_file_test_suite():
     unittest.suite(
         "v3_lock_file_tests",
-        get_artifacts_ignores_dependency_targets_without_artifacts_test,
         get_artifacts_keeps_classifier_dependency_targets_test,
-        compute_lock_file_hash_tolerates_aggregator_sharing_key_with_sibling_test,
+        compute_lock_file_hash_accepts_cleaned_aggregator_collision_test,
     )

--- a/tests/unit/v3_lock_file_test.bzl
+++ b/tests/unit/v3_lock_file_test.bzl
@@ -1,0 +1,135 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//private/rules:v3_lock_file.bzl", "v3_lock_file")
+
+def _get_artifacts_ignores_dependency_targets_without_artifacts_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    artifacts = v3_lock_file.get_artifacts({
+        "artifacts": {
+            "com.example:dep": {
+                "shasums": {
+                    "jar": "def",
+                },
+                "version": "1.0",
+            },
+            "com.example:root": {
+                "shasums": {
+                    "jar": "abc",
+                },
+                "version": "1.0",
+            },
+        },
+        "dependencies": {
+            "com.example:root": [
+                "com.example:dep",
+                "com.example:missing-native",
+            ],
+        },
+        "repositories": {},
+        "services": {},
+        "version": "3",
+    })
+
+    # `com.example:missing-native` has no artifact entry, so the dependency edge is dropped rather
+    # than emitting a dangling target reference.
+    root = [artifact for artifact in artifacts if artifact["coordinates"] == "com.example:root:1.0"][0]
+    asserts.equals(env, ["com.example:dep:spoofed-version"], root["deps"])
+
+    return unittest.end(env)
+
+get_artifacts_ignores_dependency_targets_without_artifacts_test = unittest.make(
+    _get_artifacts_ignores_dependency_targets_without_artifacts_test_impl,
+)
+
+def _get_artifacts_keeps_classifier_dependency_targets_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    artifacts = v3_lock_file.get_artifacts({
+        "artifacts": {
+            "com.example:dep": {
+                "shasums": {
+                    "test-fixtures": "def",
+                },
+                "version": "1.0",
+            },
+            "com.example:root": {
+                "shasums": {
+                    "jar": "abc",
+                },
+                "version": "1.0",
+            },
+        },
+        "dependencies": {
+            "com.example:root": [
+                "com.example:dep:jar:test-fixtures",
+                "com.example:missing-native",
+            ],
+        },
+        "repositories": {},
+        "services": {},
+        "version": "3",
+    })
+
+    # A classifier dependency target that does have a matching shasum is preserved.
+    root = [artifact for artifact in artifacts if artifact["coordinates"] == "com.example:root:1.0"][0]
+    asserts.equals(env, ["com.example:dep:spoofed-version:test-fixtures@jar"], root["deps"])
+
+    return unittest.end(env)
+
+get_artifacts_keeps_classifier_dependency_targets_test = unittest.make(
+    _get_artifacts_keeps_classifier_dependency_targets_test_impl,
+)
+
+def _compute_lock_file_hash_tolerates_aggregator_sharing_key_with_sibling_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # A binary-less aggregator (`com.example:umbrella`) shares its `group:artifact` key with a
+    # classified sibling (`com.example:umbrella:jar:unshaded`) that owns the only shasum. The plain
+    # key still appears in `repositories` and `dependencies` but is never reconstructed into the
+    # hash's intermediate map, so computing the hash must not fail on the missing key.
+    hashes = v3_lock_file.compute_lock_file_hash({
+        "artifacts": {
+            "com.example:dep": {
+                "shasums": {
+                    "jar": "def",
+                },
+                "version": "1.0",
+            },
+            "com.example:umbrella": {
+                "shasums": {
+                    "unshaded": "abc",
+                },
+                "version": "1.0",
+            },
+        },
+        "dependencies": {
+            "com.example:umbrella": ["com.example:dep"],
+            "com.example:umbrella:jar:unshaded": ["com.example:dep"],
+        },
+        "repositories": {
+            "https://example.com/repo/": [
+                "com.example:dep",
+                "com.example:umbrella",
+                "com.example:umbrella:jar:unshaded",
+            ],
+        },
+        "version": "3",
+    })
+
+    asserts.true(env, "com.example:umbrella:jar:unshaded" in hashes)
+    asserts.true(env, "com.example:dep" in hashes)
+    asserts.false(env, "com.example:umbrella" in hashes)
+
+    return unittest.end(env)
+
+compute_lock_file_hash_tolerates_aggregator_sharing_key_with_sibling_test = unittest.make(
+    _compute_lock_file_hash_tolerates_aggregator_sharing_key_with_sibling_test_impl,
+)
+
+def v3_lock_file_test_suite():
+    unittest.suite(
+        "v3_lock_file_tests",
+        get_artifacts_ignores_dependency_targets_without_artifacts_test,
+        get_artifacts_keeps_classifier_dependency_targets_test,
+        compute_lock_file_hash_tolerates_aggregator_sharing_key_with_sibling_test,
+    )


### PR DESCRIPTION
Some Gradle Module Metadata resolutions can produce coordinates that are useful for dependency graph shape but do not correspond to an emitted jar target. This exposed two ways a freshly repinned lockfile could be generated successfully but fail when Bazel later tried to use it:

 1. A binary-less aggregator coordinate could remain in `repositories` or dependency edges even though the artifact key was not emitted in `artifacts`.
 2. A POM-only Gradle artifact could be recorded as the known local path for a jar coordinate, causing the lockfile to store the POM checksum for a jar URL. The next Bazel fetch then failed because the downloaded jar did not match the pinned checksum.

This changes lockfile generation to keep the emitted artifact set and all repository/dependency references consistent.

It also tightens the Gradle resolver and downloader path handoff so a local file is only used as the known artifact path when its filename matches the coordinate being resolved. That prevents `.pom` files from being hashed as jars while still allowing real jar artifacts, including classified jars such as `jar:unshaded`, to be pinned and consumed normally.