### PR TITLE
Add support for GCS auth in both `resolution` and `jar download` phases

### DIFF
--- a/private/extensions/download_pinned_deps.bzl
+++ b/private/extensions/download_pinned_deps.bzl
@@ -41,7 +41,12 @@ def download_pinned_deps(mctx, artifacts, http_files, has_m2local):
         http_file(
             name = http_file_repository_name,
             sha256 = artifact["sha256"],
-            urls = urls,
+            urls = [
+                u.replace("gcs://", "https://storage.googleapis.com/")
+                if u.startswith("gcs://")
+                else u
+                for u in urls
+            ],
             # https://github.com/bazelbuild/rules_jvm_external/issues/1028
             downloaded_file_path = "v1/%s" % artifact["file"] if artifact["file"] else artifact["file"],
         )

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/AuthMethod.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/AuthMethod.java
@@ -1,0 +1,22 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.github.bazelbuild.rules_jvm_external.resolver.gradle;
+
+/** Authentication method for a {@link Repository}. */
+public enum AuthMethod {
+  NONE,
+  BASIC,
+  BEARER,
+}

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/BUILD
@@ -26,6 +26,7 @@ java_library(
         "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/events",
         "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/models",
         "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/netrc",
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/remote/gcs:gcs_download_service",
         artifact(
             "org.gradle:gradle-tooling-api",
             repository_name = "rules_jvm_external_deps",

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleBuildScriptGenerator.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleBuildScriptGenerator.java
@@ -116,10 +116,17 @@ public class GradleBuildScriptGenerator {
                   } else {
                     map.put("allowInsecureProtocol", false);
                   }
-                  map.put("requiresAuth", repo.requiresAuth);
-                  if (repo.requiresAuth) {
-                    map.put("usernameProperty", repo.usernameProperty);
-                    map.put("passwordProperty", repo.passwordProperty);
+                  switch (repo.authMethod) {
+                    case BEARER -> {
+                      map.put("auth", Map.of("bearer", true, "basic", false));
+                      map.put("passwordProperty", repo.passwordProperty);
+                    }
+                    case BASIC -> {
+                      map.put("auth", Map.of("bearer", false, "basic", true));
+                      map.put("usernameProperty", repo.usernameProperty);
+                      map.put("passwordProperty", repo.passwordProperty);
+                    }
+                    case NONE -> map.put("auth", Map.of("bearer", false, "basic", false));
                   }
                   return map;
                 })

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolver.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/GradleResolver.java
@@ -35,6 +35,7 @@ import com.github.bazelbuild.rules_jvm_external.resolver.gradle.models.GradleRes
 import com.github.bazelbuild.rules_jvm_external.resolver.gradle.models.GradleResolvedDependency;
 import com.github.bazelbuild.rules_jvm_external.resolver.gradle.models.GradleUnresolvedDependency;
 import com.github.bazelbuild.rules_jvm_external.resolver.netrc.Netrc;
+import com.github.bazelbuild.rules_jvm_external.resolver.remote.gcs.GcpTokenProvider;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.MutableGraph;
 import com.google.common.hash.Hashing;
@@ -146,9 +147,13 @@ public class GradleResolver implements Resolver {
       List<Repository> repositories, Path projectDir) throws MalformedURLException {
     Map<String, String> properties = new HashMap<>();
     for (Repository repository : repositories) {
-      if (repository.requiresAuth) {
-        properties.put(repository.usernameProperty, repository.getUsername());
-        properties.put(repository.passwordProperty, repository.getPassword());
+      switch (repository.authMethod) {
+        case BASIC -> {
+          properties.put(repository.usernameProperty, repository.getUsername());
+          properties.put(repository.passwordProperty, repository.getPassword());
+        }
+        case BEARER -> properties.put(repository.passwordProperty, repository.getPassword());
+        case NONE -> {}
       }
     }
 
@@ -675,12 +680,18 @@ public class GradleResolver implements Resolver {
   }
 
   private Repository createRepository(URI uri) {
+    if ("gcs".equals(uri.getScheme())) {
+      uri = URI.create(uri.toString().replace("gcs://", "https://storage.googleapis.com/"));
+      String token = new GcpTokenProvider().getAccessToken();
+      return new Repository(uri, AuthMethod.BEARER, "_", token);
+    }
+
     Netrc.Credential credential = netrc.getCredential(uri.getHost());
     if (credential == null) {
       return new Repository(uri);
     }
 
-    return new Repository(uri, true, credential.login(), credential.password());
+    return new Repository(uri, AuthMethod.BASIC, credential.login(), credential.password());
   }
 
   private GradleDependencyImpl createDependency(Artifact artifact) {

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/Repository.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/Repository.java
@@ -20,19 +20,19 @@ import java.util.Objects;
 /** Models a maven repository that is added to a gradle build script */
 public class Repository {
   public final URI uri;
-  public final boolean requiresAuth;
+  public final AuthMethod authMethod;
   public final String usernameProperty;
   public final String passwordProperty;
   private final String password;
   private final String username;
 
   public Repository(URI uri) {
-    this(uri, false, null, null);
+    this(uri, AuthMethod.NONE, null, null);
   }
 
-  public Repository(URI uri, boolean requiresAuth, String username, String password) {
+  public Repository(URI uri, AuthMethod authMethod, String username, String password) {
     this.uri = Objects.requireNonNull(uri);
-    this.requiresAuth = requiresAuth;
+    this.authMethod = authMethod;
     String host = URI.create(getUrl()).getHost();
     this.username = username;
     this.password = password;

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/data/build.gradle.hbs
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/gradle/data/build.gradle.hbs
@@ -8,7 +8,17 @@ repositories {
     maven {
         url "{{url}}"
         allowInsecureProtocol = {{allowInsecureProtocol}}
-{{~#if requiresAuth}}
+{{~#if auth.bearer}}
+        authentication {
+            header(HttpHeaderAuthentication)
+        }
+        credentials(HttpHeaderCredentials) {
+            def token = findProperty("{{passwordProperty}}")
+            if (token == null) throw new GradleException("Missing {{passwordProperty}}")
+            name = "Authorization"
+            value = "Bearer " + token
+        }
+{{~else if auth.basic}}
         credentials {
             def u = findProperty("{{usernameProperty}}")
             if (u == null) throw new GradleException("Missing {{usernameProperty}}")

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/maven/HttpDownloaderTransporterFactory.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/maven/HttpDownloaderTransporterFactory.java
@@ -55,6 +55,7 @@ public class HttpDownloaderTransporterFactory implements TransporterFactory {
     String scheme = repository.getProtocol();
     if ("http".equalsIgnoreCase(scheme)
         || "https".equalsIgnoreCase(scheme)
+        || "gcs".equalsIgnoreCase(scheme)
         || "file".equalsIgnoreCase(scheme)) {
       return new HttpDownloaderTransporter(downloadService, repository);
     }

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/remote/gcs/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/remote/gcs/BUILD
@@ -1,0 +1,24 @@
+load("@rules_java//java:java_library.bzl", "java_library")
+load("//private/rules:artifact.bzl", "artifact")
+
+java_library(
+    name = "gcs_download_service",
+    srcs = [
+        "GcsDownloadService.java",
+        "GcpTokenProvider.java",
+    ],
+    resources = ["META-INF/services/com.github.bazelbuild.rules_jvm_external.resolver.DownloadService"],
+    resource_strip_prefix = package_name(),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//resolver:resolver",
+        artifact(
+            "com.google.auth:google-auth-library-oauth2-http",
+            repository_name = "rules_jvm_external_deps",
+        ),
+        artifact(
+            "com.google.cloud:google-cloud-storage",
+            repository_name = "rules_jvm_external_deps",
+        ),
+    ],
+)

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/remote/gcs/GcpTokenProvider.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/remote/gcs/GcpTokenProvider.java
@@ -1,0 +1,63 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.github.bazelbuild.rules_jvm_external.resolver.remote.gcs;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Provides OAuth 2.0 access tokens for Google Cloud Storage using
+ * Google's official auth library with Application Default Credentials (ADC).
+ *
+ * <p>Uses {@link GoogleCredentials#getApplicationDefault()} which reads
+ * ADC from the standard locations (the same credentials used by
+ * {@code gcloud auth application-default login}).
+ */
+public class GcpTokenProvider {
+
+  private static final List<String> SCOPES =
+      List.of("https://www.googleapis.com/auth/devstorage.read_only");
+
+  private final GoogleCredentials credentials;
+
+  public GcpTokenProvider() {
+    this(createDefaultCredentials());
+  }
+
+  GcpTokenProvider(GoogleCredentials credentials) {
+    this.credentials = credentials;
+  }
+
+  private static GoogleCredentials createDefaultCredentials() {
+    try {
+      return GoogleCredentials.getApplicationDefault().createScoped(SCOPES);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to load Google Application Default Credentials", e);
+    }
+  }
+
+  /**
+   * Returns a valid access token, refreshing automatically when it expires.
+   */
+  public String getAccessToken() {
+    try {
+      credentials.refreshIfExpired();
+      return credentials.getAccessToken().getTokenValue();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to refresh GCS access token", e);
+    }
+  }
+}

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/remote/gcs/GcsDownloadService.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/remote/gcs/GcsDownloadService.java
@@ -1,0 +1,99 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.github.bazelbuild.rules_jvm_external.resolver.remote.gcs;
+
+import com.github.bazelbuild.rules_jvm_external.resolver.DownloadService;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import com.google.cloud.storage.StorageOptions;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * A {@link DownloadService} that adds Google Cloud Storage support to rules_jvm_external's
+ * Maven resolver.
+ *
+ * <p>Uses the official Google Cloud Storage client library, which handles ADC authentication,
+ * retries, and connection management automatically.
+ *
+ * <p>Non-GCS URIs are delegated to the default {@link DownloadService}.
+ */
+public class GcsDownloadService implements DownloadService {
+
+  private DownloadService defaultService;
+  private Storage storage;
+
+  @Override
+  public void initialize(DownloadService defaultService) {
+    this.defaultService = defaultService;
+    this.storage = createStorage();
+  }
+
+  protected Storage createStorage() {
+    return StorageOptions.getDefaultInstance().getService();
+  }
+
+  @Override
+  public Path get(URI uri) {
+    if (!"gcs".equals(uri.getScheme())) {
+      return defaultService.get(uri);
+    }
+    return downloadFromGcs(uri);
+  }
+
+  @Override
+  public boolean head(URI uri) {
+    if (!"gcs".equals(uri.getScheme())) {
+      return defaultService.head(uri);
+    }
+    return headGcs(uri);
+  }
+
+  private Path downloadFromGcs(URI gcsUri) {
+    BlobId blobId = toBlobId(gcsUri);
+    byte[] content;
+    try {
+      content = storage.readAllBytes(blobId);
+    } catch (StorageException e) {
+      // A missing object is not an error: the artifact simply is not in this repository, so the
+      // resolver must be free to fall through to the next one. Matches the null-on-404 contract of
+      // the default HTTP downloader. Any other failure (auth, network) is a real error and rethrown.
+      if (e.getCode() == 404) {
+        return null;
+      }
+      throw e;
+    }
+    try {
+      Path tempFile = Files.createTempFile("gcs-resolver", "download");
+      Files.write(tempFile, content);
+      return tempFile;
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private boolean headGcs(URI gcsUri) {
+    BlobId blobId = toBlobId(gcsUri);
+    return storage.get(blobId) != null;
+  }
+
+  static BlobId toBlobId(URI gcsUri) {
+    return BlobId.of(gcsUri.getHost(), gcsUri.getPath().substring(1));
+  }
+}

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/remote/gcs/META-INF/services/com.github.bazelbuild.rules_jvm_external.resolver.DownloadService
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/remote/gcs/META-INF/services/com.github.bazelbuild.rules_jvm_external.resolver.DownloadService
@@ -1,0 +1,1 @@
+com.github.bazelbuild.rules_jvm_external.resolver.remote.gcs.GcsDownloadService

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/remote/gcs/BUILD
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/remote/gcs/BUILD
@@ -1,0 +1,25 @@
+load("@rules_java//java:java_test.bzl", "java_test")
+load("//:defs.bzl", "artifact")
+
+java_test(
+    name = "GcsDownloadServiceTest",
+    size = "small",
+    srcs = ["GcsDownloadServiceTest.java"],
+    test_class = "com.github.bazelbuild.rules_jvm_external.resolver.remote.gcs.GcsDownloadServiceTest",
+    deps = [
+        "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/remote/gcs:gcs_download_service",
+        "//resolver:resolver",
+        artifact(
+            "com.google.cloud:google-cloud-storage",
+            repository_name = "rules_jvm_external_deps",
+        ),
+        artifact(
+            "junit:junit",
+            repository_name = "regression_testing_coursier",
+        ),
+        artifact(
+            "org.mockito:mockito-core",
+            repository_name = "regression_testing_coursier",
+        ),
+    ],
+)

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/remote/gcs/GcsDownloadServiceTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/remote/gcs/GcsDownloadServiceTest.java
@@ -1,0 +1,162 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.github.bazelbuild.rules_jvm_external.resolver.remote.gcs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.github.bazelbuild.rules_jvm_external.resolver.DownloadService;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Test;
+
+public class GcsDownloadServiceTest {
+
+  @Test
+  public void delegatesNonGcsGetToDefaultService() {
+    var defaultService = new RecordingDownloadService();
+    GcsDownloadService service = new GcsDownloadService();
+    service.initialize(defaultService);
+
+    URI httpUri = URI.create("https://repo1.maven.org/maven2/com/example/foo/1.0/foo-1.0.jar");
+    service.get(httpUri);
+
+    assertEquals(httpUri, defaultService.lastGetUri);
+    assertNull(defaultService.lastHeadUri);
+  }
+
+  @Test
+  public void delegatesNonGcsHeadToDefaultService() {
+    var defaultService = new RecordingDownloadService();
+    GcsDownloadService service = new GcsDownloadService();
+    service.initialize(defaultService);
+
+    URI httpUri = URI.create("https://repo1.maven.org/maven2/com/example/foo/1.0/foo-1.0.jar");
+    service.head(httpUri);
+
+    assertEquals(httpUri, defaultService.lastHeadUri);
+    assertNull(defaultService.lastGetUri);
+  }
+
+  @Test
+  public void getFromGcsReturnsDownloadedFile() throws Exception {
+    Storage storage = mock(Storage.class);
+    BlobId expected = BlobId.of("my-bucket", "artifact.jar");
+    when(storage.readAllBytes(expected)).thenReturn("hello-gcs".getBytes());
+
+    GcsDownloadService service = withStorage(storage);
+    service.initialize(new RecordingDownloadService());
+
+    Path result = service.get(URI.create("gcs://my-bucket/artifact.jar"));
+
+    assertTrue(result != null);
+    assertTrue(Files.exists(result));
+    assertEquals("hello-gcs", Files.readString(result));
+  }
+
+  @Test
+  public void getFromGcsReturnsNullWhenBlobMissing() {
+    // A 404 means the artifact is not in this repository; get() must return null so the resolver
+    // can fall through to the next repository, not abort the whole resolution.
+    Storage storage = mock(Storage.class);
+    when(storage.readAllBytes(BlobId.of("my-bucket", "missing.jar")))
+        .thenThrow(new StorageException(404, "Not Found"));
+
+    GcsDownloadService service = withStorage(storage);
+    service.initialize(new RecordingDownloadService());
+
+    assertNull(service.get(URI.create("gcs://my-bucket/missing.jar")));
+  }
+
+  @Test(expected = StorageException.class)
+  public void getFromGcsRethrowsUnexpectedStorageErrors() {
+    // Non-404 failures (auth, network, server errors) are real and must surface, not be swallowed
+    // as a missing artifact.
+    Storage storage = mock(Storage.class);
+    when(storage.readAllBytes(BlobId.of("my-bucket", "boom.jar")))
+        .thenThrow(new StorageException(500, "Internal Server Error"));
+
+    GcsDownloadService service = withStorage(storage);
+    service.initialize(new RecordingDownloadService());
+
+    service.get(URI.create("gcs://my-bucket/boom.jar"));
+  }
+
+  @Test
+  public void headGcsReturnsTrueWhenBlobExists() {
+    Storage storage = mock(Storage.class);
+    when(storage.get(BlobId.of("my-bucket", "artifact.jar"))).thenReturn(mock(Blob.class));
+
+    GcsDownloadService service = withStorage(storage);
+    service.initialize(new RecordingDownloadService());
+
+    assertTrue(service.head(URI.create("gcs://my-bucket/artifact.jar")));
+  }
+
+  @Test
+  public void headGcsReturnsFalseWhenBlobMissing() {
+    Storage storage = mock(Storage.class);
+    when(storage.get(BlobId.of("my-bucket", "missing.jar"))).thenReturn(null);
+
+    GcsDownloadService service = withStorage(storage);
+    service.initialize(new RecordingDownloadService());
+
+    assertFalse(service.head(URI.create("gcs://my-bucket/missing.jar")));
+  }
+
+  @Test
+  public void toBlobIdExtractsBucketAndPath() {
+    BlobId blobId = GcsDownloadService.toBlobId(
+        URI.create("gcs://repo.revolut.com/snapshots/com/example/foo/1.0/foo-1.0.jar"));
+
+    assertEquals("repo.revolut.com", blobId.getBucket());
+    assertEquals("snapshots/com/example/foo/1.0/foo-1.0.jar", blobId.getName());
+  }
+
+  private static GcsDownloadService withStorage(Storage storage) {
+    return new GcsDownloadService() {
+      @Override
+      protected Storage createStorage() {
+        return storage;
+      }
+    };
+  }
+
+  private static class RecordingDownloadService implements DownloadService {
+    URI lastGetUri;
+    URI lastHeadUri;
+
+    @Override
+    public Path get(URI uri) {
+      lastGetUri = uri;
+      return null;
+    }
+
+    @Override
+    public boolean head(URI uri) {
+      lastHeadUri = uri;
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Add support for GCS auth in both `resolution` and `jar download` phases:

* Resolution phase:
  * Gradle resolver: 
    * The resolver now converts `gcs://` to `https://storage.googleapis.com/`
    * Auth token is obtained using the `google-auth-library-oauth2-http` library. `GcpTokenProvider` wraps the calls to the library
  * Maven resolver: 
    * `GcsDownloadService` SPI plugin uses `google-cloud-storage` library, and delegates non-GCS URIs to the default service. `HttpDownloaderTransporterFactory` now accepts `gcs` scheme
    * Auth token is obtained by the `google-cloud-storage` library

* Jar download phase: 
  * `download_pinned_deps.bzl` converts `gcs://` to `https://` inline and uses Bazel's http_file
  * Auth token is obtained via Bazel --credential_helper (delegated to the client to configure). Example of credential helper [here](https://github.com/tweag/rules_gcs/blob/a5080a97b4cc869ccb2d00281591389c25caff63/tools/credential-helper)