### PR TITLE
fix: make Gradle resolver cache writes race-tolerant

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/remote/Downloader.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/remote/Downloader.java
@@ -14,6 +14,7 @@
 
 package com.github.bazelbuild.rules_jvm_external.resolver.remote;
 
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 import com.github.bazelbuild.rules_jvm_external.Coordinates;
@@ -28,6 +29,8 @@ import java.io.Reader;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -156,12 +159,7 @@ public class Downloader {
 
           Path cachedResult = localRepository.resolve(path);
           if (cacheDownloads && !cachedResult.equals(pathInRepo)) {
-            try {
-              Files.createDirectories(cachedResult.getParent());
-              Files.copy(pathInRepo, cachedResult, REPLACE_EXISTING);
-            } catch (IOException e) {
-              throw new UncheckedIOException(e);
-            }
+            cacheDownload(pathInRepo, cachedResult);
           }
         }
       } else if (assumedDownloaded) {
@@ -181,6 +179,35 @@ public class Downloader {
     String sha256 = calculateSha256(pathInRepo);
 
     return new DownloadResult(coordsToUse, Set.copyOf(repos), pathInRepo, sha256);
+  }
+
+  // For the Gradle resolver, localRepository is the shared Gradle module cache, which the Gradle
+  // daemon and other worker threads write to concurrently. A plain Files.copy(REPLACE_EXISTING) is
+  // not atomic: REPLACE_EXISTING only removes a target present at check time, so a target created in
+  // the TOCTOU window makes the copy fail with FileAlreadyExistsException. Write to a temp file and
+  // atomically move it into place instead. These artifacts are content-addressed, so a destination
+  // another writer already produced is correct and "already there" is success, not an error.
+  private void cacheDownload(Path source, Path destination) {
+    try {
+      Path parent = destination.getParent();
+      Files.createDirectories(parent);
+
+      Path temp = Files.createTempFile(parent, ".rje-download-", ".tmp");
+      try {
+        Files.copy(source, temp, REPLACE_EXISTING);
+        try {
+          Files.move(temp, destination, ATOMIC_MOVE, REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException e) {
+          Files.move(temp, destination, REPLACE_EXISTING);
+        }
+      } catch (FileAlreadyExistsException e) {
+        // Another writer won the race; the identical artifact is already cached.
+      } finally {
+        Files.deleteIfExists(temp);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   private URI buildUri(URI baseUri, String pathInRepo) {

--- a/tests/com/github/bazelbuild/rules_jvm_external/resolver/maven/DownloaderTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/resolver/maven/DownloaderTest.java
@@ -14,6 +14,7 @@
 
 package com.github.bazelbuild.rules_jvm_external.resolver.maven;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.github.bazelbuild.rules_jvm_external.Coordinates;
@@ -68,5 +69,35 @@ public class DownloaderTest {
             .download(coords);
 
     assertTrue(downloadResult.getPath().isEmpty());
+  }
+
+  @Test
+  public void cachingDownloadToleratesPreexistingDestination() throws IOException {
+    // When the local cache is a directory that other workers (or the Gradle daemon) also write to,
+    // a freshly-downloaded artifact's destination can already exist by the time we cache it. Since
+    // artifacts are content-addressed, that is success, not a FileAlreadyExistsException failure.
+    Coordinates coords = new Coordinates("com.example:already-cached:1.0");
+
+    Path repo = MavenRepo.create().add(coords).getPath();
+    Path localRepo = Files.createTempDirectory("local");
+
+    // Simulate a concurrent writer having already materialized the destination.
+    Path destination = localRepo.resolve(coords.toRepoPath());
+    Files.createDirectories(destination.getParent());
+    Files.createFile(destination);
+
+    DownloadResult downloadResult =
+        new Downloader(
+                Netrc.fromUserHome(),
+                localRepo,
+                Set.of(repo.toUri()),
+                new NullListener(),
+                true,
+                Map.of())
+            .download(coords);
+
+    assertNotNull(downloadResult);
+    assertTrue(downloadResult.getPath().isPresent());
+    assertTrue(Files.exists(destination));
   }
 }


### PR DESCRIPTION
## Problem

When pinning a large dependency graph with `resolver = "gradle"`, the pin aborts non-deterministically with `java.nio.file.FileAlreadyExistsException` while copying a freshly-downloaded artifact into the local cache. The failing artifact differs from run to run — whichever one loses a race between parallel downloader threads — so it reproduces on large graphs and not on small ones. Serializing the resolver (`RJE_MAX_THREADS=1`) makes it disappear, confirming a pure concurrency race.

```
java.io.UncheckedIOException: java.nio.file.FileAlreadyExistsException:
  .../.gradle/caches/modules-2/files-2.1/io/netty/.../netty-...-sources.jar
    at ...resolver.remote.Downloader.performDownload(Downloader.java)
Caused by: java.nio.file.FileAlreadyExistsException
    at java.base/java.nio.file.Files.copy(Files.java)
```

## Root cause

For the Gradle resolver, `localRepository` is the **shared** Gradle module cache (`~/.gradle/caches/modules-2/files-2.1`), which the Gradle daemon and other RJE worker threads write to concurrently. `Downloader.performDownload` cached downloads with:

```java
Files.copy(pathInRepo, cachedResult, REPLACE_EXISTING);
```

`Files.copy(REPLACE_EXISTING)` is not atomic: `REPLACE_EXISTING` only deletes a target that exists *at check time*, so a target created by another writer in the TOCTOU window makes the underlying create fail with `FileAlreadyExistsException`. A plain in-place copy also lets a concurrent worker observe a **half-written** cache file via the `Files.exists(cachedResult)` check at the top of `performDownload` and then hash a truncated artifact.

## Fix

Cache to a temp file in the destination directory, then atomically move it into place (`ATOMIC_MOVE`, with a non-atomic fallback for filesystems that don't support it). Artifacts here are content-addressed, so a destination another writer already produced is *success* — `FileAlreadyExistsException` on the move is ignored, and readers never see a partial file.

## Test

Adds `DownloaderTest.cachingDownloadToleratesPreexistingDestination`, which pre-creates the cache destination (simulating a concurrent writer) with caching enabled and asserts the download succeeds instead of throwing.