### PR TITLE
Update rules_kotlin to 2.4.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ bazel_dep(name = "package_metadata", version = "0.0.7")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_java", version = "9.3.0")
-bazel_dep(name = "rules_kotlin", version = "2.2.2")
+bazel_dep(name = "rules_kotlin", version = "2.4.0")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "toml.bzl", version = "0.3.0")
 


### PR DESCRIPTION
Updates rules_kotlin from 2.2.2 to 2.4.0 so follow-up documentation work can read kt_defs.bzl directly through Stardoc.

The dependency remains a plain Bazel Central Registry entry with no override.
