### PR TITLE
Handle overrides for fileless artifacts

### DIFF
--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -529,28 +529,28 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
             all_imports.append(
                 "alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n\tvisibility = %s,)" % (target_label, labels_to_override.get(target_label), visibility),
             )
-            if repository_ctx.attr.maven_install_json:
+            if repository_ctx.attr.maven_install_json and artifact_path != None:
                 # Provide the downloaded artifact as a file target.
                 all_imports.append(_genrule_copy_artifact_from_http_file(artifact, default_visibilities))
-            raw_artifact = dict(artifact)
-            raw_artifact["coordinates"] = "original_" + artifact["coordinates"]
-            raw_artifact["maven_coordinates"] = artifact["coordinates"]
-            raw_artifact["repository_coordinates"] = artifact["coordinates"]
-            raw_artifact["out"] = "original_" + artifact["file"]
+                raw_artifact = dict(artifact)
+                raw_artifact["coordinates"] = "original_" + artifact["coordinates"]
+                raw_artifact["maven_coordinates"] = artifact["coordinates"]
+                raw_artifact["repository_coordinates"] = artifact["coordinates"]
+                raw_artifact["out"] = "original_" + artifact["file"]
 
-            all_imports.extend(_generate_target(
-                repository_ctx,
-                jar_versionless_target_labels,
-                explicit_artifacts,
-                srcjar_paths,
-                labels_to_override,
-                repository_urls,
-                neverlink_artifacts,
-                testonly_artifacts,
-                exclusions,
-                default_visibilities,
-                raw_artifact,
-            ))
+                all_imports.extend(_generate_target(
+                    repository_ctx,
+                    jar_versionless_target_labels,
+                    explicit_artifacts,
+                    srcjar_paths,
+                    labels_to_override,
+                    repository_urls,
+                    neverlink_artifacts,
+                    testonly_artifacts,
+                    exclusions,
+                    default_visibilities,
+                    raw_artifact,
+                ))
 
         elif artifact_path != None and packaging != "pom":
             seen_imports[target_label] = True

--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -529,28 +529,30 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
             all_imports.append(
                 "alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n\tvisibility = %s,)" % (target_label, labels_to_override.get(target_label), visibility),
             )
-            if repository_ctx.attr.maven_install_json and artifact_path != None:
+            if artifact_path == None:
+                continue
+            if repository_ctx.attr.maven_install_json:
                 # Provide the downloaded artifact as a file target.
                 all_imports.append(_genrule_copy_artifact_from_http_file(artifact, default_visibilities))
-                raw_artifact = dict(artifact)
-                raw_artifact["coordinates"] = "original_" + artifact["coordinates"]
-                raw_artifact["maven_coordinates"] = artifact["coordinates"]
-                raw_artifact["repository_coordinates"] = artifact["coordinates"]
-                raw_artifact["out"] = "original_" + artifact["file"]
+            raw_artifact = dict(artifact)
+            raw_artifact["coordinates"] = "original_" + artifact["coordinates"]
+            raw_artifact["maven_coordinates"] = artifact["coordinates"]
+            raw_artifact["repository_coordinates"] = artifact["coordinates"]
+            raw_artifact["out"] = "original_" + artifact["file"]
 
-                all_imports.extend(_generate_target(
-                    repository_ctx,
-                    jar_versionless_target_labels,
-                    explicit_artifacts,
-                    srcjar_paths,
-                    labels_to_override,
-                    repository_urls,
-                    neverlink_artifacts,
-                    testonly_artifacts,
-                    exclusions,
-                    default_visibilities,
-                    raw_artifact,
-                ))
+            all_imports.extend(_generate_target(
+                repository_ctx,
+                jar_versionless_target_labels,
+                explicit_artifacts,
+                srcjar_paths,
+                labels_to_override,
+                repository_urls,
+                neverlink_artifacts,
+                testonly_artifacts,
+                exclusions,
+                default_visibilities,
+                raw_artifact,
+            ))
 
         elif artifact_path != None and packaging != "pom":
             seen_imports[target_label] = True

--- a/tests/unit/dependency_tree_parser_test.bzl
+++ b/tests/unit/dependency_tree_parser_test.bzl
@@ -173,6 +173,32 @@ def _overridden_aar_original_artifact_uses_real_http_file_repo_impl(ctx):
 
 overridden_aar_original_artifact_uses_real_http_file_repo_test = unittest.make(_overridden_aar_original_artifact_uses_real_http_file_repo_impl)
 
+def _overridden_fileless_artifact_has_no_original_target_impl(ctx):
+    env = unittest.begin(ctx)
+
+    generated_imports = _generate_imports(
+        dependencies = [
+            {
+                "coordinates": "com.example:metadata:1.0",
+                "deps": [],
+                "file": None,
+                "urls": [],
+            },
+        ],
+        exclusions = {},
+        override_targets = {
+            "com.example:metadata": "//third_party:metadata",
+        },
+        maven_install_json = True,
+    )
+
+    asserts.true(env, "name = \"com_example_metadata\"," in generated_imports)
+    asserts.false(env, "original_com_example_metadata" in generated_imports)
+
+    return unittest.end(env)
+
+overridden_fileless_artifact_has_no_original_target_test = unittest.make(_overridden_fileless_artifact_has_no_original_target_impl)
+
 def dependency_tree_parser_test_suite():
     unittest.suite(
         "dependency_tree_parser_tests",
@@ -180,4 +206,5 @@ def dependency_tree_parser_test_suite():
         wildcard_exclusion_removes_all_generated_deps_test,
         pom_only_exclusion_removes_generated_export_test,
         overridden_aar_original_artifact_uses_real_http_file_repo_test,
+        overridden_fileless_artifact_has_no_original_target_test,
     )


### PR DESCRIPTION
`maven.override` crashes while generating a pinned repository when the overridden artifact has no file, for example OkHttp's POM-only `com.squareup.okhttp3:okhttp-bom:5.1.0` ([source](https://github.com/square/okhttp), [POM](https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp-bom/5.1.0/okhttp-bom-5.1.0.pom), [no JAR](https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp-bom/5.1.0/okhttp-bom-5.1.0.jar)).

For fileless artifacts, only generate the override alias.