### PR TITLE
feat: expose kt_defs.bzl via public bzl_library for stardoc

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -7,6 +7,7 @@ exports_files([
     "extensions.bzl",
     "specs.bzl",
     "maven_install.json",
+    "kt_defs.bzl",
 ])
 
 licenses(["notice"])  # Apache 2.0
@@ -55,6 +56,19 @@ bzl_library(
         "@bazel_tools//tools:bzl_srcs",
         "@rules_java//java:rules",
     ],
+)
+
+bzl_library(                                                                                                            
+    name = "implementation-kotlin",                                                                                      
+    srcs = [                                                                                                             
+        ":kt_defs.bzl",                                                                                                  
+        "//private/rules:implementation",                                                                                
+    ],                                                                                                                   
+    visibility = [                                                                                                       
+        # Visible so downstream users can document their kt_jvm_export                                                   
+        # usage via stardoc (mirrors the java `implementation` target).                                                  
+        "//visibility:public",                                                                                           
+    ],  
 )
 
 alias(


### PR DESCRIPTION
Currently, `kt_defs.bzl` is not exported and is not included in the public `bzl_library`, so stardoc throws an error “missing bzl_library”.

The changes for Kotlin are similar to the existing public target `implementation`, the comment for which already states that it is public precisely so that users can document their code (java_export) using stardoc. 